### PR TITLE
chore: promote fmtok8s-email to version 0.0.52 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-email/fmtok8s-email-0.0.52-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email/fmtok8s-email-0.0.52-release.yaml
@@ -1,0 +1,52 @@
+# Source: fmtok8s-email/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-06T10:19:06Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-email-0.0.52'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      message: |
+        release 0.0.52
+      sha: cf85a2856af7481d01b9e96e4890c6ab7a4227cc
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        emitting events for emails related to proposals
+      sha: bffdcf21a245dc6617c85f170028b08851612267
+  gitCloneUrl: https://github.com/salaboy/fmtok8s-email.git
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-email
+  gitOwner: salaboy
+  gitRepository: fmtok8s-email
+  name: 'fmtok8s-email'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.52
+  version: v0.0.52
+status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-email/fmtok8s-email-fmtok8s-email-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email/fmtok8s-email-fmtok8s-email-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: fmtok8s-email/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-email-fmtok8s-email
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-email-0.0.52"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-email-fmtok8s-email
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-email-fmtok8s-email
+    spec:
+      containers:
+        - name: fmtok8s-email
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-email:0.0.52"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.52
+            - name: ZEEBE_CLIENT_SECURITY_PLAINTEXT
+              value: "false"
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1768Mi
+            requests:
+              cpu: 650m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/fmtok8s-email/fmtok8s-email-ingress.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email/fmtok8s-email-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-email/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-email
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-email
+              servicePort: 80
+      host: fmtok8s-email-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/fmtok8s-email/fmtok8s-email-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email/fmtok8s-email-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-email/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-email
+  labels:
+    chart: "fmtok8s-email-0.0.52"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-email-fmtok8s-email

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -98,5 +98,9 @@ releases:
   version: 0.0.71
   name: fmtok8s-agenda
   namespace: jx-staging
+- chart: dev/fmtok8s-email
+  version: 0.0.52
+  name: fmtok8s-email
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-email to version 0.0.52 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge