### PR TITLE
chore: promote fmtok8s-app to version 0.0.60 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -106,5 +106,9 @@ releases:
   version: 0.0.7
   name: fmtok8s-speakers
   namespace: jx-staging
+- chart: dev/fmtok8s-app
+  version: 0.0.60
+  name: fmtok8s-app
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-app to version 0.0.60 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge