### PR TITLE
chore: promote fmtok8s-c4p to version 0.0.67 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-c4p/fmtok8s-c4p-0.0.67-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p/fmtok8s-c4p-0.0.67-release.yaml
@@ -1,0 +1,52 @@
+# Source: fmtok8s-c4p/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-06T10:59:02Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-c4p-0.0.67'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      message: |
+        release 0.0.67
+      sha: 508f6e75edfe52e8063ddd8bce760dd47af838bc
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        emitting cloud events when proposal arrives and when decision is made
+      sha: db6613d99170c55817f7dba4fa7195b860c6bdfb
+  gitCloneUrl: https://github.com/salaboy/fmtok8s-c4p.git
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-c4p
+  gitOwner: salaboy
+  gitRepository: fmtok8s-c4p
+  name: 'fmtok8s-c4p'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.67
+  version: v0.0.67
+status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p/fmtok8s-c4p-fmtok8s-c4p-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p/fmtok8s-c4p-fmtok8s-c4p-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: fmtok8s-c4p/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-c4p-fmtok8s-c4p
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-c4p-0.0.67"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-c4p-fmtok8s-c4p
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-c4p-fmtok8s-c4p
+    spec:
+      containers:
+        - name: fmtok8s-c4p
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p:0.0.67"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.67
+            - name: ZEEBE_CLIENT_SECURITY_PLAINTEXT
+              value: "false"
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1768Mi
+            requests:
+              cpu: 650m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p/fmtok8s-c4p-ingress.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p/fmtok8s-c4p-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-c4p/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-c4p
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-c4p
+              servicePort: 80
+      host: fmtok8s-c4p-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p/fmtok8s-c4p-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p/fmtok8s-c4p-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-c4p/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-c4p
+  labels:
+    chart: "fmtok8s-c4p-0.0.67"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-c4p-fmtok8s-c4p

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -106,5 +106,9 @@ releases:
   version: 0.0.7
   name: fmtok8s-speakers
   namespace: jx-staging
+- chart: dev/fmtok8s-c4p
+  version: 0.0.67
+  name: fmtok8s-c4p
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-c4p to version 0.0.67 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge