### PR TITLE
chore: promote fmtok8s-c4p-rest to version 0.0.2 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-ingress.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-  name: fmtok8s-c4p-rest
+  name: fmtok8s-c4p
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -13,6 +13,6 @@ spec:
     - http:
         paths:
           - backend:
-              serviceName: fmtok8s-c4p-rest
+              serviceName: fmtok8s-c4p
               servicePort: 80
-      host: fmtok8s-c4p-rest-jx-staging.35.222.17.41.nip.io
+      host: fmtok8s-c4p-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-09T10:08:43Z"
+  creationTimestamp: "2020-11-09T10:58:22Z"
   deletionTimestamp: null
-  name: 'fmtok8s-c4p-rest-0.0.1'
+  name: 'fmtok8s-c4p-rest-0.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: salaboy
       message: |
-        release 0.0.1
-      sha: b283b1f11078768981fdc10e1ff654ec48d1753b
+        release 0.0.2
+      sha: ee36edaf4b1c706e87677afada2815a0d8cb156f
     - author:
         accountReference:
           - id: salaboy-2
@@ -40,29 +40,13 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        Jenkins X build pack
-      sha: db87ca92bbf51404bd0b0e6154bb38c3342dc5ce
-    - author:
-        accountReference:
-          - id: salaboy-2
-            provider: jenkins.io/git-github-userid
-        email: salaboy@gmail.com
-        name: salaboy
-      branch: master
-      committer:
-        accountReference:
-          - id: salaboy-2
-            provider: jenkins.io/git-github-userid
-        email: salaboy@gmail.com
-        name: salaboy
-      message: |
-        initial commit
-      sha: ecaac172b5c311702bbc761ba716a71f2f25be26
+        updating charts
+      sha: c7e8aa9030ff5c0507c66ad446ddded3d33f148a
   gitCloneUrl: https://github.com/salaboy/fmtok8s-c4p-rest.git
   gitHttpUrl: https://github.com/salaboy/fmtok8s-c4p-rest
   gitOwner: salaboy
   gitRepository: fmtok8s-c4p-rest
   name: 'fmtok8s-c4p-rest'
-  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p-rest/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p-rest/releases/tag/v0.0.2
+  version: v0.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fmtok8s-c4p-rest-fmtok8s-c4p-rest
   labels:
     draft: draft-app
-    chart: "fmtok8s-c4p-rest-0.0.1"
+    chart: "fmtok8s-c4p-rest-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,15 +23,17 @@ spec:
     spec:
       containers:
         - name: fmtok8s-c4p-rest
-          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p-rest:0.0.1"
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p-rest:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
+            - name: VERSION
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080
           livenessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 10
@@ -39,17 +41,17 @@ spec:
             timeoutSeconds: 1
           readinessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: 8080
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: 400m
-              memory: 256Mi
+              cpu: 1000m
+              memory: 1768Mi
             requests:
-              cpu: 200m
-              memory: 128Mi
+              cpu: 650m
+              memory: 1024Mi
       terminationGracePeriodSeconds:
       imagePullSecrets:

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: fmtok8s-c4p-rest
+  name: fmtok8s-c4p
   labels:
-    chart: "fmtok8s-c4p-rest-0.0.1"
+    chart: "fmtok8s-c4p-rest-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -111,7 +111,7 @@ releases:
   name: fmtok8s-c4p
   namespace: jx-staging
 - chart: dev/fmtok8s-c4p-rest
-  version: 0.0.1
+  version: 0.0.2
   name: fmtok8s-c4p-rest
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote fmtok8s-c4p-rest to version 0.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge