### PR TITLE
chore: promote fmtok8s-app to version 0.0.66 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -114,5 +114,9 @@ releases:
   version: 0.0.2
   name: fmtok8s-c4p-rest
   namespace: jx-staging
+- chart: dev/fmtok8s-app
+  version: 0.0.66
+  name: fmtok8s-app
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-app to version 0.0.66 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge