### PR TITLE
chore: promote fmtok8s-agenda-rest to version 0.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.1-release.yaml
@@ -1,0 +1,52 @@
+# Source: fmtok8s-agenda-rest/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-09T16:08:33Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-agenda-rest-0.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      message: |
+        release 0.0.1
+      sha: a073ec57ff6e137a6147ddf4324eab5b96da4000
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        Jenkins X build pack
+      sha: c176731af164b45ea7172af5815344e2d4d700b8
+  gitCloneUrl: https://github.com/salaboy/fmtok8s-agenda-rest.git
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-agenda-rest
+  gitOwner: salaboy
+  gitRepository: fmtok8s-agenda-rest
+  name: 'fmtok8s-agenda-rest'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-agenda-rest/releases/tag/v0.0.1
+  version: v0.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
@@ -1,0 +1,55 @@
+# Source: fmtok8s-agenda-rest/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-agenda-rest-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+    spec:
+      containers:
+        - name: fmtok8s-agenda-rest
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-agenda-rest:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-ingress.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-agenda-rest/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-agenda-rest
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-agenda-rest
+              servicePort: 80
+      host: fmtok8s-agenda-rest-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-agenda-rest/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-agenda-rest
+  labels:
+    chart: "fmtok8s-agenda-rest-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-agenda-rest-fmtok8s-agenda-rest

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -98,5 +98,9 @@ releases:
   version: 0.0.3
   name: fmtok8s-c4p-rest
   namespace: jx-staging
+- chart: dev/fmtok8s-agenda-rest
+  version: 0.0.1
+  name: fmtok8s-agenda-rest
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-agenda-rest to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge