### PR TITLE
chore: promote fmtok8s-agenda-rest to version 0.0.2 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-ingress.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-  name: fmtok8s-agenda-rest
+  name: fmtok8s-agenda
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -13,6 +13,6 @@ spec:
     - http:
         paths:
           - backend:
-              serviceName: fmtok8s-agenda-rest
+              serviceName: fmtok8s-agenda
               servicePort: 80
-      host: fmtok8s-agenda-rest-jx-staging.35.222.17.41.nip.io
+      host: fmtok8s-agenda-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-09T16:08:33Z"
+  creationTimestamp: "2020-11-09T16:16:05Z"
   deletionTimestamp: null
-  name: 'fmtok8s-agenda-rest-0.0.1'
+  name: 'fmtok8s-agenda-rest-0.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: salaboy
       message: |
-        release 0.0.1
-      sha: a073ec57ff6e137a6147ddf4324eab5b96da4000
+        release 0.0.2
+      sha: 50e1b2aa99f29871f6cbae43bcccc65324e537ec
     - author:
         accountReference:
           - id: salaboy-2
@@ -40,13 +40,13 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        Jenkins X build pack
-      sha: c176731af164b45ea7172af5815344e2d4d700b8
+        updating charts
+      sha: b0ad49d79eb37860aa2bcb6a9feeb55c2eb5650a
   gitCloneUrl: https://github.com/salaboy/fmtok8s-agenda-rest.git
   gitHttpUrl: https://github.com/salaboy/fmtok8s-agenda-rest
   gitOwner: salaboy
   gitRepository: fmtok8s-agenda-rest
   name: 'fmtok8s-agenda-rest'
-  releaseNotesURL: https://github.com/salaboy/fmtok8s-agenda-rest/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-agenda-rest/releases/tag/v0.0.2
+  version: v0.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fmtok8s-agenda-rest-fmtok8s-agenda-rest
   labels:
     draft: draft-app
-    chart: "fmtok8s-agenda-rest-0.0.1"
+    chart: "fmtok8s-agenda-rest-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,15 +23,17 @@ spec:
     spec:
       containers:
         - name: fmtok8s-agenda-rest
-          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-agenda-rest:0.0.1"
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-agenda-rest:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
+            - name: VERSION
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080
           livenessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 10
@@ -39,17 +41,17 @@ spec:
             timeoutSeconds: 1
           readinessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: 8080
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: 400m
-              memory: 256Mi
+              cpu: 1000m
+              memory: 1768Mi
             requests:
-              cpu: 200m
-              memory: 128Mi
+              cpu: 650m
+              memory: 1024Mi
       terminationGracePeriodSeconds:
       imagePullSecrets:

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: fmtok8s-agenda-rest
+  name: fmtok8s-agenda
   labels:
-    chart: "fmtok8s-agenda-rest-0.0.1"
+    chart: "fmtok8s-agenda-rest-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -99,7 +99,7 @@ releases:
   name: fmtok8s-c4p-rest
   namespace: jx-staging
 - chart: dev/fmtok8s-agenda-rest
-  version: 0.0.1
+  version: 0.0.2
   name: fmtok8s-agenda-rest
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote fmtok8s-agenda-rest to version 0.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge