### PR TITLE
chore: promote fmtok8s-email-rest to version 0.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-0.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-0.0.1-release.yaml
@@ -1,0 +1,68 @@
+# Source: fmtok8s-email-rest/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-09T16:25:49Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-email-rest-0.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      message: |
+        release 0.0.1
+      sha: fa1ad5c11085006d4d25d0c188d4975621eafdf6
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        Jenkins X build pack
+      sha: 2599cd8a74f2fee42a7c7df710002c06a35b0632
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        initial commit
+      sha: 652a1dd58172b5a89a2f0428014902d338ad319f
+  gitCloneUrl: https://github.com/salaboy/fmtok8s-email-rest.git
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-email-rest
+  gitOwner: salaboy
+  gitRepository: fmtok8s-email-rest
+  name: 'fmtok8s-email-rest'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-email-rest/releases/tag/v0.0.1
+  version: v0.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-deploy.yaml
@@ -1,0 +1,57 @@
+# Source: fmtok8s-email-rest/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-email-rest-fmtok8s-email-rest
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-email-rest-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-email-rest-fmtok8s-email-rest
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-email-rest-fmtok8s-email-rest
+    spec:
+      containers:
+        - name: fmtok8s-email-rest
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-email-rest:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-ingress.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-email-rest/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-email-rest
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-email-rest
+              servicePort: 80
+      host: fmtok8s-email-rest-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-email-rest/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-email-rest
+  labels:
+    chart: "fmtok8s-email-rest-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-email-rest-fmtok8s-email-rest

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -102,5 +102,9 @@ releases:
   version: 0.0.2
   name: fmtok8s-agenda-rest
   namespace: jx-staging
+- chart: dev/fmtok8s-email-rest
+  version: 0.0.1
+  name: fmtok8s-email-rest
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-email-rest to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge