### PR TITLE
chore: promote fmtok8s-api-gateway to version 0.0.121 in Staging environment

### DIFF
--- a/config-root/cluster/jx-staging/fmtok8s-api-gateway/releases.jenkins.io-crd.yaml
+++ b/config-root/cluster/jx-staging/fmtok8s-api-gateway/releases.jenkins.io-crd.yaml
@@ -1,0 +1,712 @@
+# Source: fmtok8s-api-gateway/crds/jenkins-x-release-crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: releases.jenkins.io
+  labels:
+    gitops.jenkins-x.io/pipeline: 'cluster'
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .spec.name
+      description: The name of the Release
+      name: Name
+      type: string
+    - JSONPath: .spec.version
+      description: The version number of the Release
+      name: Version
+      type: string
+    - JSONPath: .spec.gitHttpUrl
+      description: The URL of the Git repository
+      name: Git URL
+      type: string
+  conversion:
+    strategy: None
+  group: jenkins.io
+  names:
+    categories:
+      - all
+    kind: Release
+    listKind: ReleaseList
+    plural: releases
+    shortNames:
+      - rel
+    singular: release
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: Release represents a single version of an app that has been released
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+          properties:
+            annotations:
+              description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+            clusterName:
+              description: The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+              type: string
+            creationTimestamp:
+              description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+              format: date-time
+              type: string
+            deletionGracePeriodSeconds:
+              description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+              format: int64
+              type: integer
+            deletionTimestamp:
+              description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+              format: date-time
+              type: string
+            finalizers:
+              description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.
+              items:
+                type: string
+              type: array
+            generateName:
+              description: |-
+                GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+              type: string
+            generation:
+              description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+              format: int64
+              type: integer
+            initializers:
+              description: Initializers tracks the progress of initialization.
+              properties:
+                pending:
+                  description: Pending is a list of initializers that must execute in order before this object is visible. When the last pending initializer is removed, and no failing result is set, the initializers struct will be set to nil and the object is considered as initialized and visible to all clients.
+                  items:
+                    description: Initializer is information about an initializer that has not yet completed.
+                    properties:
+                      name:
+                        description: name of the process that is responsible for initializing this object.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                result:
+                  description: Status is a return value for calls that don't return other objects.
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    code:
+                      description: Suggested HTTP return code for this status, 0 if not set.
+                      format: int32
+                      type: integer
+                    details:
+                      description: StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.
+                      properties:
+                        causes:
+                          description: The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.
+                          items:
+                            description: StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.
+                            properties:
+                              field:
+                                description: |-
+                                  The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                  Examples:
+                                    "name" - the field "name" on the current resource
+                                    "items[0].name" - the field "name" on the first array entry in "items"
+                                type: string
+                              message:
+                                description: A human-readable description of the cause of the error.  This field may be presented as-is to a reader.
+                                type: string
+                              reason:
+                                description: A machine-readable description of the cause of the error. If this value is empty there is no information available.
+                                type: string
+                            type: object
+                          type: array
+                        group:
+                          description: The group attribute of the resource associated with the status StatusReason.
+                          type: string
+                        kind:
+                          description: 'The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).
+                          type: string
+                        retryAfterSeconds:
+                          description: If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.
+                          format: int32
+                          type: integer
+                        uid:
+                          description: 'UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                          type: string
+                      type: object
+                    kind:
+                      description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    message:
+                      description: A human-readable description of the status of this operation.
+                      type: string
+                    metadata:
+                      description: ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.
+                      properties:
+                        continue:
+                          description: continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.
+                          type: string
+                        resourceVersion:
+                          description: 'String that identifies the server''s internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        selfLink:
+                          description: selfLink is a URL representing this object. Populated by the system. Read-only.
+                          type: string
+                      type: object
+                    reason:
+                      description: A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
+                      type: string
+                    status:
+                      description: 'Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                      type: string
+                  type: object
+              required:
+                - pending
+              type: object
+            labels:
+              description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            name:
+              description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: |-
+                Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+              type: string
+            ownerReferences:
+              description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+              items:
+                description: OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  blockOwnerDeletion:
+                    description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                    type: boolean
+                  controller:
+                    description: If true, this reference points to the managing controller.
+                    type: boolean
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                    type: string
+                required:
+                  - apiVersion
+                  - kind
+                  - name
+                  - uid
+                type: object
+              type: array
+            resourceVersion:
+              description: |-
+                An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+              type: string
+            selfLink:
+              description: SelfLink is a URL representing this object. Populated by the system. Read-only.
+              type: string
+            uid:
+              description: |-
+                UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+              type: string
+          type: object
+        spec:
+          description: ReleaseSpec is the specification of the Release
+          properties:
+            commits:
+              items:
+                description: CommitSummary is the summary of a commit
+                properties:
+                  author:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  branch:
+                    type: string
+                  committer:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  issueIds:
+                    items:
+                      type: string
+                    type: array
+                  message:
+                    type: string
+                  sha:
+                    type: string
+                  url:
+                    type: string
+                type: object
+              type: array
+            dependencyUpdates:
+              items:
+                description: DependencyUpdate describes an dependency update message from the commit log
+                properties:
+                  component:
+                    type: string
+                  fromReleaseHTMLURL:
+                    type: string
+                  fromReleaseName:
+                    type: string
+                  fromVersion:
+                    type: string
+                  host:
+                    type: string
+                  owner:
+                    type: string
+                  paths:
+                    items:
+                      items:
+                        description: DependencyUpdateDetails are the details of a dependency update
+                        properties:
+                          component:
+                            type: string
+                          fromReleaseHTMLURL:
+                            type: string
+                          fromReleaseName:
+                            type: string
+                          fromVersion:
+                            type: string
+                          host:
+                            type: string
+                          owner:
+                            type: string
+                          repo:
+                            type: string
+                          toReleaseHTMLURL:
+                            type: string
+                          toReleaseName:
+                            type: string
+                          toVersion:
+                            type: string
+                          url:
+                            type: string
+                        required:
+                          - host
+                          - owner
+                          - repo
+                          - url
+                          - fromVersion
+                          - fromReleaseHTMLURL
+                          - fromReleaseName
+                          - toVersion
+                          - toReleaseHTMLURL
+                          - toReleaseName
+                        type: object
+                      type: array
+                    type: array
+                  repo:
+                    type: string
+                  toReleaseHTMLURL:
+                    type: string
+                  toReleaseName:
+                    type: string
+                  toVersion:
+                    type: string
+                  url:
+                    type: string
+                required:
+                  - host
+                  - owner
+                  - repo
+                  - url
+                  - fromVersion
+                  - fromReleaseHTMLURL
+                  - fromReleaseName
+                  - toVersion
+                  - toReleaseHTMLURL
+                  - toReleaseName
+                type: object
+              type: array
+            gitCloneUrl:
+              type: string
+            gitHttpUrl:
+              type: string
+            gitOwner:
+              type: string
+            gitRepository:
+              type: string
+            issues:
+              items:
+                description: IssueSummary is the summary of an issue
+                properties:
+                  assignees:
+                    items:
+                      description: UserDetails containers details of a user
+                      properties:
+                        accountReference:
+                          items:
+                            description: AccountReference is a reference to a user account in another system that is attached to this user
+                            properties:
+                              id:
+                                type: string
+                              provider:
+                                type: string
+                            type: object
+                          type: array
+                        avatarUrl:
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                          format: date-time
+                          type: string
+                        email:
+                          type: string
+                        externalUser:
+                          type: boolean
+                        login:
+                          type: string
+                        name:
+                          type: string
+                        serviceAccount:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                  body:
+                    type: string
+                  closedBy:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  creationTimestamp:
+                    description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                    format: date-time
+                    type: string
+                  id:
+                    type: string
+                  labels:
+                    items:
+                      properties:
+                        color:
+                          type: string
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                  message:
+                    type: string
+                  state:
+                    type: string
+                  title:
+                    type: string
+                  url:
+                    type: string
+                  user:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                type: object
+              type: array
+            name:
+              type: string
+            pullRequests:
+              items:
+                description: IssueSummary is the summary of an issue
+                properties:
+                  assignees:
+                    items:
+                      description: UserDetails containers details of a user
+                      properties:
+                        accountReference:
+                          items:
+                            description: AccountReference is a reference to a user account in another system that is attached to this user
+                            properties:
+                              id:
+                                type: string
+                              provider:
+                                type: string
+                            type: object
+                          type: array
+                        avatarUrl:
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                          format: date-time
+                          type: string
+                        email:
+                          type: string
+                        externalUser:
+                          type: boolean
+                        login:
+                          type: string
+                        name:
+                          type: string
+                        serviceAccount:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                  body:
+                    type: string
+                  closedBy:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  creationTimestamp:
+                    description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                    format: date-time
+                    type: string
+                  id:
+                    type: string
+                  labels:
+                    items:
+                      properties:
+                        color:
+                          type: string
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                  message:
+                    type: string
+                  state:
+                    type: string
+                  title:
+                    type: string
+                  url:
+                    type: string
+                  user:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                type: object
+              type: array
+            releaseNotesURL:
+              type: string
+            version:
+              type: string
+          type: object
+        status:
+          description: ReleaseStatus is the status of a release
+          properties:
+            status:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    categories:
+      - all
+    kind: Release
+    listKind: ReleaseList
+    plural: releases
+    shortNames:
+      - rel
+    singular: release
+  conditions:
+    - lastTransitionTime: "2020-03-30T19:10:44Z"
+      message: no conflicts found
+      reason: NoConflicts
+      status: "True"
+      type: NamesAccepted
+    - lastTransitionTime: null
+      message: the initial names have been accepted
+      reason: InitialNamesAccepted
+      status: "True"
+      type: Established
+  storedVersions:
+    - v1

--- a/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-0.0.121-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-0.0.121-release.yaml
@@ -1,0 +1,52 @@
+# Source: fmtok8s-api-gateway/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-09T16:43:57Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-api-gateway-0.0.121'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      message: |
+        release 0.0.121
+      sha: 014391c437c481b9fb0485a7ff1f1682fa82c874
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        dynamic links for services
+      sha: 1c51b13c81be5d601b1c4afe9ed5cba35d52d257
+  gitCloneUrl: https://github.com/salaboy/fmtok8s-api-gateway.git
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-api-gateway
+  gitOwner: salaboy
+  gitRepository: fmtok8s-api-gateway
+  name: 'fmtok8s-api-gateway'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.121
+  version: v0.0.121
+status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-fmtok8s-api-gateway-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-fmtok8s-api-gateway-deploy.yaml
@@ -1,0 +1,57 @@
+# Source: fmtok8s-api-gateway/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-api-gateway-fmtok8s-api-gateway
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-api-gateway-0.0.121"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-api-gateway-fmtok8s-api-gateway
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-api-gateway-fmtok8s-api-gateway
+    spec:
+      containers:
+        - name: fmtok8s-api-gateway
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-api-gateway:0.0.121"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.121
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1500m
+              memory: 1768Mi
+            requests:
+              cpu: 750m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-ingress.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-api-gateway/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-api-gateway
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-api-gateway
+              servicePort: 80
+      host: fmtok8s-api-gateway-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-api-gateway/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-api-gateway
+  labels:
+    chart: "fmtok8s-api-gateway-0.0.121"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-api-gateway-fmtok8s-api-gateway

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -106,5 +106,9 @@ releases:
   version: 0.0.1
   name: fmtok8s-email-rest
   namespace: jx-staging
+- chart: dev/fmtok8s-api-gateway
+  version: 0.0.121
+  name: fmtok8s-api-gateway
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-api-gateway to version 0.0.121 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge