### PR TITLE
chore: promote fmtok8s-api-gateway to version 0.0.123 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -107,7 +107,7 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-staging
 - chart: dev/fmtok8s-api-gateway
-  version: 0.0.121
+  version: 0.0.123
   name: fmtok8s-api-gateway
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote fmtok8s-api-gateway to version 0.0.123 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge