### PR TITLE
chore: promote fmtok8s-email-rest to version 0.0.3 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-ingress.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-  name: fmtok8s-email-rest
+  name: fmtok8s-email
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -13,6 +13,6 @@ spec:
     - http:
         paths:
           - backend:
-              serviceName: fmtok8s-email-rest
+              serviceName: fmtok8s-email
               servicePort: 80
-      host: fmtok8s-email-rest-jx-staging.35.222.17.41.nip.io
+      host: fmtok8s-email-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-0.0.3-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-0.0.3-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-09T16:25:49Z"
+  creationTimestamp: "2020-11-09T18:56:59Z"
   deletionTimestamp: null
-  name: 'fmtok8s-email-rest-0.0.1'
+  name: 'fmtok8s-email-rest-0.0.3'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: salaboy
       message: |
-        release 0.0.1
-      sha: fa1ad5c11085006d4d25d0c188d4975621eafdf6
+        release 0.0.3
+      sha: 0f66e60dd537a9c9645228fedfedefaa947bec75
     - author:
         accountReference:
           - id: salaboy-2
@@ -40,29 +40,13 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        Jenkins X build pack
-      sha: 2599cd8a74f2fee42a7c7df710002c06a35b0632
-    - author:
-        accountReference:
-          - id: salaboy-2
-            provider: jenkins.io/git-github-userid
-        email: salaboy@gmail.com
-        name: salaboy
-      branch: master
-      committer:
-        accountReference:
-          - id: salaboy-2
-            provider: jenkins.io/git-github-userid
-        email: salaboy@gmail.com
-        name: salaboy
-      message: |
-        initial commit
-      sha: 652a1dd58172b5a89a2f0428014902d338ad319f
+        setting events off by default
+      sha: 0a0c8354922d19743ea0ef4d12604e7341c3e476
   gitCloneUrl: https://github.com/salaboy/fmtok8s-email-rest.git
   gitHttpUrl: https://github.com/salaboy/fmtok8s-email-rest
   gitOwner: salaboy
   gitRepository: fmtok8s-email-rest
   name: 'fmtok8s-email-rest'
-  releaseNotesURL: https://github.com/salaboy/fmtok8s-email-rest/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-email-rest/releases/tag/v0.0.3
+  version: v0.0.3
 status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fmtok8s-email-rest-fmtok8s-email-rest
   labels:
     draft: draft-app
-    chart: "fmtok8s-email-rest-0.0.1"
+    chart: "fmtok8s-email-rest-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,17 +23,17 @@ spec:
     spec:
       containers:
         - name: fmtok8s-email-rest
-          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-email-rest:0.0.1"
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-email-rest:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.3
           envFrom: null
           ports:
             - containerPort: 8080
           livenessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 10
@@ -41,17 +41,17 @@ spec:
             timeoutSeconds: 1
           readinessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: 8080
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: 400m
-              memory: 256Mi
+              cpu: 1000m
+              memory: 1768Mi
             requests:
-              cpu: 200m
-              memory: 128Mi
+              cpu: 650m
+              memory: 1024Mi
       terminationGracePeriodSeconds:
       imagePullSecrets:

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-svc.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: fmtok8s-email-rest
+  name: fmtok8s-email
   labels:
-    chart: "fmtok8s-email-rest-0.0.1"
+    chart: "fmtok8s-email-rest-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -103,7 +103,7 @@ releases:
   name: fmtok8s-agenda-rest
   namespace: jx-staging
 - chart: dev/fmtok8s-email-rest
-  version: 0.0.1
+  version: 0.0.3
   name: fmtok8s-email-rest
   namespace: jx-staging
 - chart: dev/fmtok8s-api-gateway


### PR DESCRIPTION
chore: promote fmtok8s-email-rest to version 0.0.3 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge