### PR TITLE
chore: promote fmtok8s-agenda-rest to version 0.0.3 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.3-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.3-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-09T16:16:05Z"
+  creationTimestamp: "2020-11-09T18:58:55Z"
   deletionTimestamp: null
-  name: 'fmtok8s-agenda-rest-0.0.2'
+  name: 'fmtok8s-agenda-rest-0.0.3'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: salaboy
       message: |
-        release 0.0.2
-      sha: 50e1b2aa99f29871f6cbae43bcccc65324e537ec
+        release 0.0.3
+      sha: d57e5b1b7ce5588922ba123d910b2c7c50404a12
     - author:
         accountReference:
           - id: salaboy-2
@@ -40,13 +40,13 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        updating charts
-      sha: b0ad49d79eb37860aa2bcb6a9feeb55c2eb5650a
+        setting events off by default
+      sha: 06dd9d85a6e9f856a03465c20aa288dc6815ea61
   gitCloneUrl: https://github.com/salaboy/fmtok8s-agenda-rest.git
   gitHttpUrl: https://github.com/salaboy/fmtok8s-agenda-rest
   gitOwner: salaboy
   gitRepository: fmtok8s-agenda-rest
   name: 'fmtok8s-agenda-rest'
-  releaseNotesURL: https://github.com/salaboy/fmtok8s-agenda-rest/releases/tag/v0.0.2
-  version: v0.0.2
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-agenda-rest/releases/tag/v0.0.3
+  version: v0.0.3
 status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fmtok8s-agenda-rest-fmtok8s-agenda-rest
   labels:
     draft: draft-app
-    chart: "fmtok8s-agenda-rest-0.0.2"
+    chart: "fmtok8s-agenda-rest-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,11 +23,11 @@ spec:
     spec:
       containers:
         - name: fmtok8s-agenda-rest
-          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-agenda-rest:0.0.2"
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-agenda-rest:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.3
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: fmtok8s-agenda
   labels:
-    chart: "fmtok8s-agenda-rest-0.0.2"
+    chart: "fmtok8s-agenda-rest-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -99,7 +99,7 @@ releases:
   name: fmtok8s-c4p-rest
   namespace: jx-staging
 - chart: dev/fmtok8s-agenda-rest
-  version: 0.0.2
+  version: 0.0.3
   name: fmtok8s-agenda-rest
   namespace: jx-staging
 - chart: dev/fmtok8s-email-rest


### PR DESCRIPTION
chore: promote fmtok8s-agenda-rest to version 0.0.3 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge