### PR TITLE
chore: promote fmtok8s-c4p-rest to version 0.0.7 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.7-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.7-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-10T11:44:06Z"
+  creationTimestamp: "2020-11-10T12:00:30Z"
   deletionTimestamp: null
-  name: 'fmtok8s-c4p-rest-0.0.6'
+  name: 'fmtok8s-c4p-rest-0.0.7'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: salaboy
       message: |
-        release 0.0.6
-      sha: 268baadc975eabc5f4b2b66f760ae92711de5480
+        release 0.0.7
+      sha: f48359a301ae81f2e1407c4e4e2a65fc47572bc3
     - author:
         accountReference:
           - id: salaboy-2
@@ -40,13 +40,13 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        emitting events all cases
-      sha: ee3e2377ba7eb0424f5726ba5be5cf35b863e696
+        sending proposal id to agenda service
+      sha: c717dfdbfa00f42d110cd76a24e4216dc9129f42
   gitCloneUrl: https://github.com/salaboy/fmtok8s-c4p-rest.git
   gitHttpUrl: https://github.com/salaboy/fmtok8s-c4p-rest
   gitOwner: salaboy
   gitRepository: fmtok8s-c4p-rest
   name: 'fmtok8s-c4p-rest'
-  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p-rest/releases/tag/v0.0.6
-  version: v0.0.6
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p-rest/releases/tag/v0.0.7
+  version: v0.0.7
 status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fmtok8s-c4p-rest-fmtok8s-c4p-rest
   labels:
     draft: draft-app
-    chart: "fmtok8s-c4p-rest-0.0.6"
+    chart: "fmtok8s-c4p-rest-0.0.7"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,11 +23,11 @@ spec:
     spec:
       containers:
         - name: fmtok8s-c4p-rest
-          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p-rest:0.0.6"
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p-rest:0.0.7"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.6
+              value: 0.0.7
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: fmtok8s-c4p
   labels:
-    chart: "fmtok8s-c4p-rest-0.0.6"
+    chart: "fmtok8s-c4p-rest-0.0.7"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -95,7 +95,7 @@ releases:
   values:
   - versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
 - chart: dev/fmtok8s-c4p-rest
-  version: 0.0.6
+  version: 0.0.7
   name: fmtok8s-c4p-rest
   namespace: jx-staging
 - chart: dev/fmtok8s-agenda-rest


### PR DESCRIPTION
chore: promote fmtok8s-c4p-rest to version 0.0.7 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge