### PR TITLE
chore: promote fmtok8s-api-gateway to version 0.0.125 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-0.0.125-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-0.0.125-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-09T18:32:11Z"
+  creationTimestamp: "2020-11-11T11:04:17Z"
   deletionTimestamp: null
-  name: 'fmtok8s-api-gateway-0.0.124'
+  name: 'fmtok8s-api-gateway-0.0.125'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: salaboy
       message: |
-        release 0.0.124
-      sha: 6a9441c02c0544b8991ffb641ca922e08b8c21e8
+        release 0.0.125
+      sha: 786e2a20ebf0d5a4d2c27e17239990d4e1be737b
     - author:
         accountReference:
           - id: salaboy-2
@@ -40,13 +40,13 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        fixing typo in backoffice
-      sha: 844d6c84d26c9f695dee10ae6dcdf4bb407fc711
+        qcon logo
+      sha: 6588db31e871a893fffe6a8bfe8c3e906bd5a7a9
   gitCloneUrl: https://github.com/salaboy/fmtok8s-api-gateway.git
   gitHttpUrl: https://github.com/salaboy/fmtok8s-api-gateway
   gitOwner: salaboy
   gitRepository: fmtok8s-api-gateway
   name: 'fmtok8s-api-gateway'
-  releaseNotesURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.124
-  version: v0.0.124
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.125
+  version: v0.0.125
 status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-fmtok8s-api-gateway-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-fmtok8s-api-gateway-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fmtok8s-api-gateway-fmtok8s-api-gateway
   labels:
     draft: draft-app
-    chart: "fmtok8s-api-gateway-0.0.124"
+    chart: "fmtok8s-api-gateway-0.0.125"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,11 +23,11 @@ spec:
     spec:
       containers:
         - name: fmtok8s-api-gateway
-          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-api-gateway:0.0.124"
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-api-gateway:0.0.125"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.124
+              value: 0.0.125
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-api-gateway/fmtok8s-api-gateway-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: fmtok8s-api-gateway
   labels:
-    chart: "fmtok8s-api-gateway-0.0.124"
+    chart: "fmtok8s-api-gateway-0.0.125"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -107,7 +107,7 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-staging
 - chart: dev/fmtok8s-api-gateway
-  version: 0.0.124
+  version: 0.0.125
   name: fmtok8s-api-gateway
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote fmtok8s-api-gateway to version 0.0.125 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge