### PR TITLE
chore: promote fmtok8s-speakers to version 0.0.14 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -110,5 +110,9 @@ releases:
   version: 0.0.125
   name: fmtok8s-api-gateway
   namespace: jx-staging
+- chart: dev/fmtok8s-speakers
+  version: 0.0.14
+  name: fmtok8s-speakers
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-speakers to version 0.0.14 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge