### PR TITLE
chore: import repository https://github.com/zeebe-io/zeebe-cluster-helm.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -30,4 +30,5 @@ spec:
     providerKind: github
     repositories:
     - name: zeebe-cloud-events-router
+    - name: zeebe-cluster-helm
     scheduler: in-repo


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/docs/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges