### PR TITLE
chore: promote zeebe-operate-helm to version 0.0.29 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/templates/tests/zeebe-operate-helm-test-connection-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/templates/tests/zeebe-operate-helm-test-connection-pod.yaml
@@ -1,0 +1,22 @@
+# Source: zeebe-operate-helm/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "zeebe-operate-helm-test-connection"
+  labels:
+    app.kubernetes.io/name: zeebe-operate-helm
+    helm.sh/chart: zeebe-operate-helm-0.0.29
+    app.kubernetes.io/instance: zeebe-operate-helm
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: Helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    "helm.sh/hook": test-success
+  namespace: jx-staging
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['zeebe-operate-helm:80']
+  restartPolicy: Never

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-0.0.29-release.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-0.0.29-release.yaml
@@ -1,0 +1,68 @@
+# Source: zeebe-operate-helm/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-30T12:58:52Z"
+  deletionTimestamp: null
+  name: 'zeebe-operate-helm-0.0.29'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      message: |
+        chore: added variables
+      sha: 1e7138cb5c39040e11ddf61725364ed8510a47f3
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        chore: Jenkins X build pack
+      sha: 37994e66174cb9a5686218e69d240d8eae605cf9
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        moving to jx3 and helm3
+      sha: 88c4da54bb8098532ab62733f767df14d0283e53
+  gitCloneUrl: https://github.com/zeebe-io/zeebe-operate-helm.git
+  gitHttpUrl: https://github.com/zeebe-io/zeebe-operate-helm
+  gitOwner: zeebe-io
+  gitRepository: zeebe-operate-helm
+  name: 'zeebe-operate-helm'
+  releaseNotesURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.29
+  version: v0.0.29
+status: {}

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-cm.yaml
@@ -1,0 +1,40 @@
+# Source: zeebe-operate-helm/templates/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: zeebe-operate-helm
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+apiVersion: v1
+data:
+  application.yml: |
+    # Operate configuration file
+    camunda.operate:
+      # ELS instance to store Operate data
+      elasticsearch:
+        # Cluster name
+        clusterName: elasticsearch
+        # Host
+        host: elasticsearch-master
+        # Transport port
+        port: 9200
+      # Zeebe instance
+      zeebe:
+        # Broker contact point
+        brokerContactPoint: zeebe-operate-helm-zeebe-gateway:26500
+      # ELS instance to export Zeebe data to
+      zeebeElasticsearch:
+        # Cluster name
+        clusterName: elasticsearch
+        # Host
+        host: elasticsearch-master
+        # Transport port
+        port: 9200
+        # Index prefix, configured in Zeebe Elasticsearch exporter
+        prefix: zeebe-record
+    logging:
+      level:
+        ROOT: INFO
+        org.camunda.operate: DEBUG
+    #Spring Boot Actuator endpoints to be exposed
+    management.endpoints.web.exposure.include: health,info,conditions,configprops,prometheus

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-deploy.yaml
@@ -1,0 +1,45 @@
+# Source: zeebe-operate-helm/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zeebe-operate-helm
+  labels:
+    app: zeebe-operate-helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zeebe-operate-helm
+  template:
+    metadata:
+      labels:
+        app: zeebe-operate-helm
+    spec:
+      containers:
+        - name: zeebe-operate-helm
+          image: "gcr.io/camunda-researchanddevelopment/zeebe-operate-helm:0.0.29"
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 768Mi
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/operate/config/application.yml
+              subPath: application.yml
+      volumes:
+        - name: config
+          configMap:
+            name: zeebe-operate-helm
+            defaultMode: 0744
+      securityContext: null

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-ingress.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-ingress.yaml
@@ -1,0 +1,26 @@
+# Source: zeebe-operate-helm/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: zeebe-operate-helm
+  labels:
+    app.kubernetes.io/name: zeebe-operate-helm
+    helm.sh/chart: zeebe-operate-helm-0.0.29
+    app.kubernetes.io/instance: zeebe-operate-helm
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: Helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  namespace: jx-staging
+spec:
+  rules:
+    - host:
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: zeebe-operate-helm
+              servicePort: 80

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-svc.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-svc.yaml
@@ -1,0 +1,18 @@
+# Source: zeebe-operate-helm/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: zeebe-operate-helm
+  labels:
+    app: zeebe-operate-helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: zeebe-operate-helm

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -96,5 +96,9 @@ releases:
   version: 0.0.155
   name: zeebe-cluster
   namespace: jx-staging
+- chart: dev/zeebe-operate-helm
+  version: 0.0.29
+  name: zeebe-operate-helm
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote zeebe-operate-helm to version 0.0.29 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge