### PR TITLE
chore: promote zeebe-operate-helm to version 0.0.33 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/templates/tests/zeebe-operate-helm-test-connection-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/templates/tests/zeebe-operate-helm-test-connection-pod.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "zeebe-operate-helm-test-connection"
   labels:
     app.kubernetes.io/name: zeebe-operate-helm
-    helm.sh/chart: zeebe-operate-helm-0.0.29
+    helm.sh/chart: zeebe-operate-helm-0.0.33
     app.kubernetes.io/instance: zeebe-operate-helm
     app.kubernetes.io/version: "1.0"
     app.kubernetes.io/managed-by: Helm

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-0.0.33-release.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-0.0.33-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-30T12:58:52Z"
+  creationTimestamp: "2020-11-30T15:16:39Z"
   deletionTimestamp: null
-  name: 'zeebe-operate-helm-0.0.29'
+  name: 'zeebe-operate-helm-0.0.33'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -25,7 +25,7 @@ spec:
         name: salaboy
       message: |
         chore: added variables
-      sha: 1e7138cb5c39040e11ddf61725364ed8510a47f3
+      sha: e6019bd8f059354e7f8e9a28c910ad680eac5ee3
     - author:
         accountReference:
           - id: salaboy-2
@@ -40,29 +40,13 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        chore: Jenkins X build pack
-      sha: 37994e66174cb9a5686218e69d240d8eae605cf9
-    - author:
-        accountReference:
-          - id: salaboy-2
-            provider: jenkins.io/git-github-userid
-        email: salaboy@gmail.com
-        name: salaboy
-      branch: master
-      committer:
-        accountReference:
-          - id: salaboy-2
-            provider: jenkins.io/git-github-userid
-        email: salaboy@gmail.com
-        name: salaboy
-      message: |
-        moving to jx3 and helm3
-      sha: 88c4da54bb8098532ab62733f767df14d0283e53
+        updating chart name to follow conventions
+      sha: 2ffa166562acc7cce3c673160da4ef0820007e44
   gitCloneUrl: https://github.com/zeebe-io/zeebe-operate-helm.git
   gitHttpUrl: https://github.com/zeebe-io/zeebe-operate-helm
   gitOwner: zeebe-io
   gitRepository: zeebe-operate-helm
   name: 'zeebe-operate-helm'
-  releaseNotesURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.29
-  version: v0.0.29
+  releaseNotesURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.33
+  version: v0.0.33
 status: {}

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: zeebe-operate-helm
-          image: "gcr.io/camunda-researchanddevelopment/zeebe-operate-helm:0.0.29"
+          image: "gcr.io/camunda-researchanddevelopment/zeebe-operate-helm:0.0.33"
           resources:
             requests:
               cpu: 500m

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-ingress.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: zeebe-operate-helm
   labels:
     app.kubernetes.io/name: zeebe-operate-helm
-    helm.sh/chart: zeebe-operate-helm-0.0.29
+    helm.sh/chart: zeebe-operate-helm-0.0.33
     app.kubernetes.io/instance: zeebe-operate-helm
     app.kubernetes.io/version: "1.0"
     app.kubernetes.io/managed-by: Helm

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -97,7 +97,7 @@ releases:
   name: zeebe-cluster
   namespace: jx-staging
 - chart: dev/zeebe-operate-helm
-  version: 0.0.29
+  version: 0.0.33
   name: zeebe-operate-helm
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote zeebe-operate-helm to version 0.0.33 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge