### PR TITLE
chore: promote zeebe-cluster to version 0.0.167 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -30,62 +30,46 @@ releases:
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/jxboot-helmfile-resources/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: external-secrets/kubernetes-external-secrets
   version: 5.2.0
   name: kubernetes-external-secrets
   namespace: secret-infra
   values:
   - versionStream/charts/external-secrets/kubernetes-external-secrets/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jenkins-x-crds
   version: 3.0.5
   name: jenkins-x-crds
   namespace: jx
   values:
   - versionStream/charts/jx3/jenkins-x-crds/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-pipelines-visualizer
   version: 0.0.52
   name: jx-pipelines-visualizer
   namespace: jx
   values:
   - versionStream/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-preview
   version: 0.0.116
   name: jx-preview
   namespace: jx
-  forceNamespace: ""
-  skipDeps: null
 - chart: stable/nginx-ingress
   version: 1.39.1
   name: nginx-ingress
   namespace: nginx
   values:
   - versionStream/charts/stable/nginx-ingress/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: cdf/tekton-pipeline
   version: 0.18.0-1
   name: tekton-pipeline
   namespace: tekton-pipelines
   values:
   - versionStream/charts/cdf/tekton-pipeline/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jenkins-x/lighthouse
   version: 0.0.874
   name: lighthouse
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/lighthouse/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jenkins-x/nexus
   version: 0.1.35
   name: nexus
@@ -94,42 +78,29 @@ releases:
   - versionStream/charts/jenkins-x/nexus/values.yaml.gotmpl
   - persistence:
       size: 30Gi
-  forceNamespace: ""
-  skipDeps: null
 - chart: stable/chartmuseum
   version: 2.4.1
   name: chartmuseum
   namespace: jx
   values:
   - versionStream/charts/stable/chartmuseum/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/pusher-wave
   version: 0.4.12
   name: pusher-wave
   namespace: secret-infra
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-build-controller
   version: 0.0.14
   name: jx-build-controller
   namespace: jx
   values:
   - versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/zeebe-cluster
-  version: 0.0.155
+  version: 0.0.167
   name: zeebe-cluster
   namespace: jx-staging
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/zeebe-operate-helm
   version: 0.0.33
   name: zeebe-operate-helm
   namespace: jx-staging
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
 missingFileHandler: ""
-renderedvalues: {}


### PR DESCRIPTION
chore: promote zeebe-cluster to version 0.0.167 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge