### PR TITLE
chore: promote zeebe-cluster to version 0.0.184 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -93,7 +93,7 @@ releases:
   values:
   - versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
 - chart: dev/zeebe-cluster
-  version: 0.0.155
+  version: 0.0.184
   name: zeebe-cluster
   namespace: jx-staging
 - chart: dev/zeebe-operate-helm


### PR DESCRIPTION
chore: promote zeebe-cluster to version 0.0.184 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge