### PR TITLE
chore: promote zeebe-cluster-helm to version 0.0.193 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -100,5 +100,9 @@ releases:
   version: 0.0.33
   name: zeebe-operate-helm
   namespace: jx-staging
+- chart: dev/zeebe-cluster-helm
+  version: 0.0.193
+  name: zeebe-cluster-helm
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote zeebe-cluster-helm to version 0.0.193 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge