### PR TITLE
chore: promote zeebe-operate-helm to version 0.0.34 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -97,7 +97,7 @@ releases:
   name: zeebe-cluster
   namespace: jx-staging
 - chart: dev/zeebe-operate-helm
-  version: 0.0.33
+  version: 0.0.34
   name: zeebe-operate-helm
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote zeebe-operate-helm to version 0.0.34 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge