### PR TITLE
chore: promote zeebe-operate-helm to version 0.0.35 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-klsrg-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-klsrg-test-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-cluster-helm-whkyq-test"
+  name: "zeebe-cluster-helm-klsrg-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-cluster-helm-xnccn-test"
+    - name: "zeebe-cluster-helm-ddxxx-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/templates/tests/zeebe-operate-helm-test-connection-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/templates/tests/zeebe-operate-helm-test-connection-pod.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "zeebe-operate-helm-test-connection"
   labels:
     app.kubernetes.io/name: zeebe-operate-helm
-    helm.sh/chart: zeebe-operate-helm-0.0.33
+    helm.sh/chart: zeebe-operate-helm-0.0.35
     app.kubernetes.io/instance: zeebe-operate-helm
     app.kubernetes.io/version: "1.0"
     app.kubernetes.io/managed-by: Helm

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-0.0.35-release.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-0.0.35-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-30T15:16:39Z"
+  creationTimestamp: "2020-12-01T11:51:50Z"
   deletionTimestamp: null
-  name: 'zeebe-operate-helm-0.0.33'
+  name: 'zeebe-operate-helm-0.0.35'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -25,7 +25,7 @@ spec:
         name: salaboy
       message: |
         chore: added variables
-      sha: e6019bd8f059354e7f8e9a28c910ad680eac5ee3
+      sha: f529ae5b4bed795ddd365d4d915eb69d6edd7b32
     - author:
         accountReference:
           - id: salaboy-2
@@ -40,13 +40,13 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        updating chart name to follow conventions
-      sha: 2ffa166562acc7cce3c673160da4ef0820007e44
+        removing no-release flag
+      sha: 83cf9953e9f80df8ad0d40253175f84c832df27d
   gitCloneUrl: https://github.com/zeebe-io/zeebe-operate-helm.git
   gitHttpUrl: https://github.com/zeebe-io/zeebe-operate-helm
   gitOwner: zeebe-io
   gitRepository: zeebe-operate-helm
   name: 'zeebe-operate-helm'
-  releaseNotesURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.33
-  version: v0.0.33
+  releaseNotesURL: https://github.com/zeebe-io/zeebe-operate-helm/releases/tag/v0.0.35
+  version: v0.0.35
 status: {}

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: zeebe-operate-helm
-          image: "gcr.io/camunda-researchanddevelopment/zeebe-operate-helm:0.0.33"
+          image: "gcr.io/camunda-researchanddevelopment/zeebe-operate-helm:0.0.35"
           resources:
             requests:
               cpu: 500m

--- a/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-ingress.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operate-helm/zeebe-operate-helm-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: zeebe-operate-helm
   labels:
     app.kubernetes.io/name: zeebe-operate-helm
-    helm.sh/chart: zeebe-operate-helm-0.0.33
+    helm.sh/chart: zeebe-operate-helm-0.0.35
     app.kubernetes.io/instance: zeebe-operate-helm
     app.kubernetes.io/version: "1.0"
     app.kubernetes.io/managed-by: Helm

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -97,7 +97,7 @@ releases:
   name: zeebe-cluster
   namespace: jx-staging
 - chart: dev/zeebe-operate-helm
-  version: 0.0.33
+  version: 0.0.35
   name: zeebe-operate-helm
   namespace: jx-staging
 - chart: dev/zeebe-cluster-helm


### PR DESCRIPTION
chore: promote zeebe-operate-helm to version 0.0.35 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge