### PR TITLE
chore: promote zeebe-zeeqs-helm to version 0.0.18 in Staging environment

### DIFF
--- a/config-root/cluster/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-jx-staging-clusterrole.yaml
+++ b/config-root/cluster/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-jx-staging-clusterrole.yaml
@@ -1,0 +1,21 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zeebe-zeeqs-helm-hazelcast-jx-staging
+  labels:
+    app.kubernetes.io/name: hazelcast
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    gitops.jenkins-x.io/pipeline: 'cluster'
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list

--- a/config-root/cluster/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-jx-staging-crb.yaml
+++ b/config-root/cluster/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-jx-staging-crb.yaml
@@ -1,0 +1,19 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zeebe-zeeqs-helm-hazelcast-jx-staging
+  labels:
+    app.kubernetes.io/name: hazelcast
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    gitops.jenkins-x.io/pipeline: 'cluster'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zeebe-zeeqs-helm-hazelcast-jx-staging
+subjects:
+  - kind: ServiceAccount
+    name: zeebe-zeeqs-helm-hazelcast
+    namespace: jx-staging

--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-pqpbh-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-pqpbh-test-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-cluster-helm-owhwp-test"
+  name: "zeebe-cluster-helm-pqpbh-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-cluster-helm-dwwmc-test"
+    - name: "zeebe-cluster-helm-lactr-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-qtu40-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-qtu40-pod.yaml
@@ -1,0 +1,48 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-management-center.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-qtu40"
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+  labels:
+    app.kubernetes.io/name: hazelcast
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/component: "test"
+    role: test
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
+  containers:
+    - name: "zeebe-zeeqs-helm-hazelcast-mancenter-test"
+      image: "hazelcast/hazelcast:4.1"
+      command:
+        - "bash"
+        - "-c"
+        - |
+          set -ex
+          # Get the HTTP Response Code of the Health Check
+          HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null zeebe-zeeqs-helm-hazelcast-mancenter:8080/health)
+          # Test the currect number of Hazelcast members
+          test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        privileged: false
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+  restartPolicy: Never

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-luxx8-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-luxx8-pod.yaml
@@ -1,0 +1,48 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-hazelcast.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "zeebe-zeeqs-helm-hazelcast-test-luxx8"
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+  labels:
+    app.kubernetes.io/name: hazelcast
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/component: "test"
+    role: test
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
+  containers:
+    - name: "zeebe-zeeqs-helm-hazelcast-test"
+      image: "hazelcast/hazelcast:4.1"
+      command:
+        - "bash"
+        - "-c"
+        - |
+          set -ex
+          # Get the number of Hazelcast members in the cluster
+          CLUSTER_SIZE=$(curl zeebe-zeeqs-helm-hazelcast:5701/hazelcast/health/cluster-size)
+          # Test the currect number of Hazelcast members
+          test ${CLUSTER_SIZE} -eq 3
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        privileged: false
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+  restartPolicy: Never

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-configuration-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-configuration-cm.yaml
@@ -1,0 +1,28 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zeebe-zeeqs-helm-hazelcast-configuration
+  labels:
+    app.kubernetes.io/name: hazelcast
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+data:
+  hazelcast.yaml: |-
+    hazelcast:
+      network:
+        join:
+          kubernetes:
+            enabled: true
+            namespace: ${namespace}
+            service-name: ${serviceName}
+          multicast:
+            enabled: false
+        rest-api:
+          enabled: true
+          endpoint-groups:
+            HEALTH_CHECK:
+              enabled: true

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-mancenter-configuration-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-mancenter-configuration-cm.yaml
@@ -1,0 +1,20 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/mancenter-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zeebe-zeeqs-helm-hazelcast-mancenter-configuration
+  labels:
+    app.kubernetes.io/name: hazelcast-mancenter
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+data:
+  hazelcast-client.yaml: |-
+    hazelcast-client:
+      network:
+        kubernetes:
+          enabled: true
+          namespace: ${namespace}
+          service-name: ${serviceName}

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-mancenter-statefulset.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-mancenter-statefulset.yaml
@@ -1,0 +1,108 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/mancenter-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zeebe-zeeqs-helm-hazelcast-mancenter
+  labels:
+    app.kubernetes.io/name: hazelcast-mancenter
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  serviceName: zeebe-zeeqs-helm-hazelcast-mancenter
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hazelcast-mancenter
+      app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+      role: mancenter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hazelcast-mancenter
+        helm.sh/chart: hazelcast-3.5.0
+        app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+        app.kubernetes.io/managed-by: "Helm"
+        role: mancenter
+    spec:
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+      containers:
+        - name: zeebe-zeeqs-helm-hazelcast-mancenter
+          image: "hazelcast/management-center:4.2020.10"
+          imagePullPolicy: "IfNotPresent"
+          resources: null
+          ports:
+            - name: mancenter
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: mancenter-storage
+              mountPath: /data
+          env:
+            - name: MC_LICENSE_KEY
+              value:
+            - name: MC_INIT_CMD
+              value: "./mc-conf.sh cluster add --lenient=true -H /data -cc /config/hazelcast-client.yaml"
+            - name: JAVA_OPTS
+              value: " -Dhazelcast.mc.healthCheck.enable=true -DserviceName=zeebe-zeeqs-helm-hazelcast -Dnamespace=jx-staging -Dhazelcast.mc.tls.enabled=false "
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            privileged: false
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      securityContext:
+        fsGroup: 65534
+      serviceAccountName: zeebe-zeeqs-helm-hazelcast
+      automountServiceAccountToken: true
+      volumes:
+        - name: config
+          configMap:
+            name: zeebe-zeeqs-helm-hazelcast-mancenter-configuration
+        - name: mancenter-storage
+  volumeClaimTemplates:
+    - metadata:
+        name: mancenter-storage
+        labels:
+          app.kubernetes.io/name: hazelcast-mancenter
+          helm.sh/chart: "hazelcast-3.5.0"
+          app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+          app.kubernetes.io/managed-by: "Helm"
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-mancenter-svc.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-mancenter-svc.yaml
@@ -1,0 +1,27 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/mancenter-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: zeebe-zeeqs-helm-hazelcast-mancenter
+  labels:
+    app.kubernetes.io/name: hazelcast-mancenter
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: hazelcast-mancenter
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    role: mancenter
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: mancenter
+      name: http
+    - protocol: TCP
+      port: 443
+      targetPort: mancenter
+      name: https

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-sa.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-sa.yaml
@@ -1,0 +1,12 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zeebe-zeeqs-helm-hazelcast
+  labels:
+    app.kubernetes.io/name: hazelcast
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-statefulset.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-statefulset.yaml
@@ -1,0 +1,93 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zeebe-zeeqs-helm-hazelcast
+  labels:
+    app.kubernetes.io/name: hazelcast
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  serviceName: zeebe-zeeqs-helm-hazelcast
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hazelcast
+      app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+      role: hazelcast
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hazelcast
+        helm.sh/chart: hazelcast-3.5.0
+        app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+        app.kubernetes.io/managed-by: "Helm"
+        role: hazelcast
+      annotations:
+        checksum/hazelcast-config: b6d39a9c43a56af9ebb59e1a70e6467460996d848dabf9789e06e7e817f5ff37
+    spec:
+      terminationGracePeriodSeconds: 600
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+      containers:
+        - name: zeebe-zeeqs-helm-hazelcast
+          image: "hazelcast/hazelcast:4.1"
+          imagePullPolicy: "IfNotPresent"
+          resources: null
+          ports:
+            - name: hazelcast
+              containerPort: 5701
+              hostPort:
+          livenessProbe:
+            httpGet:
+              path: /hazelcast/health/node-state
+              port: 5701
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /hazelcast/health/ready
+              port: 5701
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          volumeMounts:
+            - name: hazelcast-storage
+              mountPath: /data/hazelcast
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: JAVA_OPTS
+              value: "-Dhazelcast.config=/data/hazelcast/hazelcast.yaml -DserviceName=zeebe-zeeqs-helm-hazelcast -Dnamespace=jx-staging -Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait=600   "
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            privileged: false
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      serviceAccountName: zeebe-zeeqs-helm-hazelcast
+      automountServiceAccountToken: true
+      volumes:
+        - name: hazelcast-storage
+          configMap:
+            name: zeebe-zeeqs-helm-hazelcast-configuration

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-svc.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/zeebe-zeeqs-helm-hazelcast-svc.yaml
@@ -1,0 +1,24 @@
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: zeebe-zeeqs-helm-hazelcast
+  labels:
+    app.kubernetes.io/name: hazelcast
+    helm.sh/chart: hazelcast-3.5.0
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    app.kubernetes.io/managed-by: "Helm"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: hazelcast
+    app.kubernetes.io/instance: "zeebe-zeeqs-helm"
+    role: hazelcast
+  ports:
+    - protocol: TCP
+      port: 5701
+      targetPort: hazelcast
+      name: hzport

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/templates/tests/zeebe-zeeqs-helm-test-connection-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/templates/tests/zeebe-zeeqs-helm-test-connection-pod.yaml
@@ -1,0 +1,22 @@
+# Source: zeebe-zeeqs-helm/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "zeebe-zeeqs-helm-test-connection"
+  labels:
+    app.kubernetes.io/name: zeebe-zeeqs-helm
+    helm.sh/chart: zeebe-zeeqs-helm-0.0.18
+    app.kubernetes.io/instance: zeebe-zeeqs-helm
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: Helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    "helm.sh/hook": test-success
+  namespace: jx-staging
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['zeebe-zeeqs-helm:9000']
+  restartPolicy: Never

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-0.0.18-release.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-0.0.18-release.yaml
@@ -1,0 +1,39 @@
+# Source: zeebe-zeeqs-helm/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-01T12:16:28Z"
+  deletionTimestamp: null
+  name: 'zeebe-zeeqs-helm-0.0.18'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: added variables
+      sha: 1eb78508facae30902113707f7761648c1d780a0
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        hazelcast own repo
+      sha: d63a429badf088a5a242198f4b1a48dabf09981e
+  gitHttpUrl: https://github.com/zeebe-io/zeebe-zeeqs-helm
+  gitOwner: zeebe-io
+  gitRepository: zeebe-zeeqs-helm
+  name: 'zeebe-zeeqs-helm'
+  releaseNotesURL: https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.18
+  version: v0.0.18
+status: {}

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-deploy.yaml
@@ -1,0 +1,41 @@
+# Source: zeebe-zeeqs-helm/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zeebe-zeeqs-helm
+  labels:
+    app: zeebe-zeeqs-helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zeebe-zeeqs-helm
+  template:
+    metadata:
+      labels:
+        app: zeebe-zeeqs-helm
+    spec:
+      containers:
+        - name: zeebe-zeeqs-helm
+          image: "gcr.io/camunda-researchanddevelopment/zeebe-zeeqs-helm:0.0.18"
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi
+          env:
+            - name: SERVER_PORT
+              value: "9000"
+            - name: ZEEBE_HAZELCAST_CONNECTION
+              value: zeebe-zeeqs-helm-hazelcast:5701
+          ports:
+            - containerPort: 9000
+              name: http
+              protocol: TCP
+      securityContext: null

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-svc.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-svc.yaml
@@ -1,0 +1,18 @@
+# Source: zeebe-zeeqs-helm/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: zeebe-zeeqs-helm
+  labels:
+    app: zeebe-zeeqs-helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      name: http
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: zeebe-zeeqs-helm

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -104,5 +104,9 @@ releases:
   version: 0.0.200
   name: zeebe-cluster-helm
   namespace: jx-staging
+- chart: dev/zeebe-zeeqs-helm
+  version: 0.0.18
+  name: zeebe-zeeqs-helm
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote zeebe-zeeqs-helm to version 0.0.18 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge