### PR TITLE
chore: promote zeebe-tasklist-helm to version 0.0.7 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-jxjfw-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-jxjfw-test-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-cluster-helm-lsrfl-test"
+  name: "zeebe-cluster-helm-jxjfw-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-cluster-helm-eaawy-test"
+    - name: "zeebe-cluster-helm-ozvgi-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-tasklist-helm/templates/tests/zeebe-tasklist-helm-test-connection-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-tasklist-helm/templates/tests/zeebe-tasklist-helm-test-connection-pod.yaml
@@ -1,0 +1,22 @@
+# Source: zeebe-tasklist-helm/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "zeebe-tasklist-helm-test-connection"
+  labels:
+    app.kubernetes.io/name: zeebe-tasklist-helm
+    helm.sh/chart: zeebe-tasklist-helm-0.0.7
+    app.kubernetes.io/instance: zeebe-tasklist-helm
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: Helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    "helm.sh/hook": test-success
+  namespace: jx-staging
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['zeebe-tasklist-helm:80']
+  restartPolicy: Never

--- a/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-0.0.7-release.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-0.0.7-release.yaml
@@ -1,0 +1,49 @@
+# Source: zeebe-tasklist-helm/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-01T12:30:09Z"
+  deletionTimestamp: null
+  name: 'zeebe-tasklist-helm-0.0.7'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: added variables
+      sha: ab561eb9d5a2b316125e3f75ba5b650214bbb60b
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        adding pipelines
+      sha: c674b0e97b0c68bbc3a8d5cc0776026d3bdb55bf
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        updating to helm3 and jx3
+      sha: 7c6e2f6f9532ebf77e5bb8e1101d1fcf1ddd9b97
+  gitHttpUrl: https://github.com/zeebe-io/zeebe-tasklist-helm
+  gitOwner: zeebe-io
+  gitRepository: zeebe-tasklist-helm
+  name: 'zeebe-tasklist-helm'
+  releaseNotesURL: https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.7
+  version: v0.0.7
+status: {}

--- a/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-cm.yaml
@@ -1,0 +1,44 @@
+# Source: zeebe-tasklist-helm/templates/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: zeebe-tasklist-helm
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+apiVersion: v1
+data:
+  application.yml: |
+    # Tasklist configuration file
+
+    zeebe.tasklist:
+      # Set Tasklist username and password.
+      # If user with <username> does not exists it will be created.
+      # Default: demo/demo
+      #username:
+      #password:
+      # ELS instance to store Tasklist data
+      elasticsearch:
+        # Cluster name
+        clusterName: elasticsearch
+        # Host
+        host: elasticsearch-master
+        # Transport port
+        port: 9200
+      # Zeebe instance
+      zeebe:
+        # Broker contact point
+        brokerContactPoint: zeebe-tasklist-helm-zeebe-gateway:26500
+      # ELS instance to export Zeebe data to
+      zeebeElasticsearch:
+        # Cluster name
+        clusterName: elasticsearch
+        # Host
+        host: elasticsearch-master
+        # Transport port
+        port: 9200
+        # Index prefix, configured in Zeebe Elasticsearch exporter
+        prefix: zeebe-record
+    #Spring Boot Actuator endpoints to be exposed
+    management.endpoints.web.exposure.include: health,info,conditions,configprops,prometheus
+    # Enable or disable metrics
+    #management.metrics.export.prometheus.enabled: false

--- a/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-deploy.yaml
@@ -1,0 +1,52 @@
+# Source: zeebe-tasklist-helm/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zeebe-tasklist-helm
+  labels:
+    app: zeebe-tasklist-helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zeebe-tasklist-helm
+  template:
+    metadata:
+      labels:
+        app: zeebe-tasklist-helm
+    spec:
+      containers:
+        - name: zeebe-tasklist-helm
+          image: "gcr.io/camunda-researchanddevelopment/zeebe-tasklist-helm:0.0.7"
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "dev,dev-data,auth"
+            - name: GRAPHQL_PLAYGROUND_ENABLED
+              value: "true"
+            - name: GRAPHQL_PLAYGROUND_SETTINGS_REQUEST_CREDENTIALS
+              value: "include"
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 768Mi
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /app/resources/application.yml
+              subPath: application.yml
+      volumes:
+        - name: config
+          configMap:
+            name: zeebe-tasklist-helm
+            defaultMode: 0744
+      securityContext: null

--- a/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-ingress.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-ingress.yaml
@@ -1,0 +1,26 @@
+# Source: zeebe-tasklist-helm/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: zeebe-tasklist-helm
+  labels:
+    app.kubernetes.io/name: zeebe-tasklist-helm
+    helm.sh/chart: zeebe-tasklist-helm-0.0.7
+    app.kubernetes.io/instance: zeebe-tasklist-helm
+    app.kubernetes.io/version: "1.0"
+    app.kubernetes.io/managed-by: Helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  namespace: jx-staging
+spec:
+  rules:
+    - host:
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: zeebe-tasklist-helm
+              servicePort: 80

--- a/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-svc.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-svc.yaml
@@ -1,0 +1,18 @@
+# Source: zeebe-tasklist-helm/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: zeebe-tasklist-helm
+  labels:
+    app: zeebe-tasklist-helm
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: zeebe-tasklist-helm

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-hbzz6-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-hbzz6-pod.yaml
@@ -1,8 +1,8 @@
-# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-hazelcast.yaml
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-management-center.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-test-4kiev"
+  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-hbzz6"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
@@ -24,17 +24,17 @@ spec:
     runAsUser: 1001
     runAsGroup: 1001
   containers:
-    - name: "zeebe-zeeqs-helm-hazelcast-test"
+    - name: "zeebe-zeeqs-helm-hazelcast-mancenter-test"
       image: "hazelcast/hazelcast:4.1"
       command:
         - "bash"
         - "-c"
         - |
           set -ex
-          # Get the number of Hazelcast members in the cluster
-          CLUSTER_SIZE=$(curl zeebe-zeeqs-helm-hazelcast:5701/hazelcast/health/cluster-size)
+          # Get the HTTP Response Code of the Health Check
+          HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null zeebe-zeeqs-helm-hazelcast-mancenter:8080/health)
           # Test the currect number of Hazelcast members
-          test ${CLUSTER_SIZE} -eq 3
+          test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-9ilpd-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-9ilpd-pod.yaml
@@ -1,8 +1,8 @@
-# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-management-center.yaml
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-hazelcast.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-13sp3"
+  name: "zeebe-zeeqs-helm-hazelcast-test-9ilpd"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
@@ -24,17 +24,17 @@ spec:
     runAsUser: 1001
     runAsGroup: 1001
   containers:
-    - name: "zeebe-zeeqs-helm-hazelcast-mancenter-test"
+    - name: "zeebe-zeeqs-helm-hazelcast-test"
       image: "hazelcast/hazelcast:4.1"
       command:
         - "bash"
         - "-c"
         - |
           set -ex
-          # Get the HTTP Response Code of the Health Check
-          HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null zeebe-zeeqs-helm-hazelcast-mancenter:8080/health)
+          # Get the number of Hazelcast members in the cluster
+          CLUSTER_SIZE=$(curl zeebe-zeeqs-helm-hazelcast:5701/hazelcast/health/cluster-size)
           # Test the currect number of Hazelcast members
-          test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
+          test ${CLUSTER_SIZE} -eq 3
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -108,5 +108,9 @@ releases:
   version: 0.0.18
   name: zeebe-zeeqs-helm
   namespace: jx-staging
+- chart: dev/zeebe-tasklist-helm
+  version: 0.0.7
+  name: zeebe-tasklist-helm
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote zeebe-tasklist-helm to version 0.0.7 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge