### PR TITLE
chore: promote zeebe-full-helm to version 0.0.118 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -108,5 +108,9 @@ releases:
   version: 0.0.18
   name: zeebe-zeeqs-helm
   namespace: jx-staging
+- chart: dev/zeebe-full-helm
+  version: 0.0.118
+  name: zeebe-full-helm
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote zeebe-full-helm to version 0.0.118 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge