### PR TITLE
chore: promote zeebe-full-helm to version 0.0.119 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -112,5 +112,9 @@ releases:
   version: 0.0.7
   name: zeebe-tasklist-helm
   namespace: jx-staging
+- chart: dev/zeebe-full-helm
+  version: 0.0.119
+  name: zeebe-full-helm
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote zeebe-full-helm to version 0.0.119 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge