### PR TITLE
chore: promote zeebe-cluster-helm to version 0.0.201 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-bzrdf-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-bzrdf-test-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-cluster-helm-urlmr-test"
+  name: "zeebe-cluster-helm-bzrdf-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-cluster-helm-yqvqj-test"
+    - name: "zeebe-cluster-helm-xsvzd-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-0.0.201-release.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-0.0.201-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-01T11:46:28Z"
+  creationTimestamp: "2020-12-01T13:01:40Z"
   deletionTimestamp: null
-  name: 'zeebe-cluster-helm-0.0.200'
+  name: 'zeebe-cluster-helm-0.0.201'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -25,7 +25,7 @@ spec:
         name: salaboy
       message: |
         chore: added variables
-      sha: 4e84caf95827109e229c88f2034d6dc7232aa863
+      sha: fb12167e6b9d2dead69a2d35c29ce7d7c62cac65
     - author:
         accountReference:
           - id: salaboy-2
@@ -40,13 +40,13 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        removing no-release flag
-      sha: 31fe7a7f0535ffad768e9987cce6fcc18fc34f4d
+        replace tag only at begining of line
+      sha: a9ac695e4126dd1c6f47d5676629716477546423
   gitCloneUrl: https://github.com/zeebe-io/zeebe-cluster-helm.git
   gitHttpUrl: https://github.com/zeebe-io/zeebe-cluster-helm
   gitOwner: zeebe-io
   gitRepository: zeebe-cluster-helm
   name: 'zeebe-cluster-helm'
-  releaseNotesURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.200
-  version: v0.0.200
+  releaseNotesURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.201
+  version: v0.0.201
 status: {}

--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-zeebe-gateway-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-zeebe-gateway-deploy.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: zeebe-cluster-helm
-          image: "gcr.io/camunda-researchanddevelopment/zeebe-cluster-helm:0.0.200"
+          image: "gcr.io/camunda-researchanddevelopment/zeebe-cluster-helm:0.25.0"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9600

--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-zeebe-statefulset.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-zeebe-statefulset.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
       containers:
         - name: zeebe-cluster-helm
-          image: "gcr.io/camunda-researchanddevelopment/zeebe-cluster-helm:0.0.200"
+          image: "gcr.io/camunda-researchanddevelopment/zeebe-cluster-helm:0.25.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: ZEEBE_BROKER_CLUSTER_CLUSTERNAME

--- a/config-root/namespaces/jx-staging/zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-full-helm-dcwdl-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-full-helm-dcwdl-test-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-full-helm-ldiso-test"
+  name: "zeebe-full-helm-dcwdl-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-full-helm-uignq-test"
+    - name: "zeebe-full-helm-kkyun-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-6mdvw-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-6mdvw-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-dksp9"
+  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-6mdvw"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-d2kpm-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-d2kpm-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-test-vrc8m"
+  name: "zeebe-zeeqs-helm-hazelcast-test-d2kpm"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -101,7 +101,7 @@ releases:
   name: zeebe-operate-helm
   namespace: jx-staging
 - chart: dev/zeebe-cluster-helm
-  version: 0.0.200
+  version: 0.0.201
   name: zeebe-cluster-helm
   namespace: jx-staging
 - chart: dev/zeebe-zeeqs-helm


### PR DESCRIPTION
chore: promote zeebe-cluster-helm to version 0.0.201 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge