### PR TITLE
chore: promote zeebe-cluster-helm to version 0.0.202 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-vozru-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-vozru-test-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-cluster-helm-urlmr-test"
+  name: "zeebe-cluster-helm-vozru-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-cluster-helm-yqvqj-test"
+    - name: "zeebe-cluster-helm-jdqkl-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-0.0.202-release.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-0.0.202-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-01T11:46:28Z"
+  creationTimestamp: "2020-12-01T13:04:27Z"
   deletionTimestamp: null
-  name: 'zeebe-cluster-helm-0.0.200'
+  name: 'zeebe-cluster-helm-0.0.202'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -25,7 +25,7 @@ spec:
         name: salaboy
       message: |
         chore: added variables
-      sha: 4e84caf95827109e229c88f2034d6dc7232aa863
+      sha: 93fccdbbadf8e4533121ee065355cc4778e4931f
     - author:
         accountReference:
           - id: salaboy-2
@@ -40,13 +40,13 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        removing no-release flag
-      sha: 31fe7a7f0535ffad768e9987cce6fcc18fc34f4d
+        also checking for repository only at the beginning of a new line
+      sha: c3de5f948c1710f866bbecf6ca7a6577f3abf6a9
   gitCloneUrl: https://github.com/zeebe-io/zeebe-cluster-helm.git
   gitHttpUrl: https://github.com/zeebe-io/zeebe-cluster-helm
   gitOwner: zeebe-io
   gitRepository: zeebe-cluster-helm
   name: 'zeebe-cluster-helm'
-  releaseNotesURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.200
-  version: v0.0.200
+  releaseNotesURL: https://github.com/zeebe-io/zeebe-cluster-helm/releases/tag/v0.0.202
+  version: v0.0.202
 status: {}

--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-zeebe-gateway-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-zeebe-gateway-deploy.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: zeebe-cluster-helm
-          image: "gcr.io/camunda-researchanddevelopment/zeebe-cluster-helm:0.0.200"
+          image: "camunda/zeebe:0.25.0"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9600

--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-zeebe-statefulset.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/zeebe-cluster-helm-zeebe-statefulset.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
       containers:
         - name: zeebe-cluster-helm
-          image: "gcr.io/camunda-researchanddevelopment/zeebe-cluster-helm:0.0.200"
+          image: "camunda/zeebe:0.25.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: ZEEBE_BROKER_CLUSTER_CLUSTERNAME

--- a/config-root/namespaces/jx-staging/zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-full-helm-aongj-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-full-helm-aongj-test-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-full-helm-ldiso-test"
+  name: "zeebe-full-helm-aongj-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-full-helm-uignq-test"
+    - name: "zeebe-full-helm-surry-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-ucdu0-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-ucdu0-pod.yaml
@@ -1,8 +1,8 @@
-# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-hazelcast.yaml
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-management-center.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-test-vrc8m"
+  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-ucdu0"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
@@ -24,17 +24,17 @@ spec:
     runAsUser: 1001
     runAsGroup: 1001
   containers:
-    - name: "zeebe-zeeqs-helm-hazelcast-test"
+    - name: "zeebe-zeeqs-helm-hazelcast-mancenter-test"
       image: "hazelcast/hazelcast:4.1"
       command:
         - "bash"
         - "-c"
         - |
           set -ex
-          # Get the number of Hazelcast members in the cluster
-          CLUSTER_SIZE=$(curl zeebe-zeeqs-helm-hazelcast:5701/hazelcast/health/cluster-size)
+          # Get the HTTP Response Code of the Health Check
+          HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null zeebe-zeeqs-helm-hazelcast-mancenter:8080/health)
           # Test the currect number of Hazelcast members
-          test ${CLUSTER_SIZE} -eq 3
+          test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-o4ij0-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-o4ij0-pod.yaml
@@ -1,8 +1,8 @@
-# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-management-center.yaml
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-hazelcast.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-dksp9"
+  name: "zeebe-zeeqs-helm-hazelcast-test-o4ij0"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
@@ -24,17 +24,17 @@ spec:
     runAsUser: 1001
     runAsGroup: 1001
   containers:
-    - name: "zeebe-zeeqs-helm-hazelcast-mancenter-test"
+    - name: "zeebe-zeeqs-helm-hazelcast-test"
       image: "hazelcast/hazelcast:4.1"
       command:
         - "bash"
         - "-c"
         - |
           set -ex
-          # Get the HTTP Response Code of the Health Check
-          HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null zeebe-zeeqs-helm-hazelcast-mancenter:8080/health)
+          # Get the number of Hazelcast members in the cluster
+          CLUSTER_SIZE=$(curl zeebe-zeeqs-helm-hazelcast:5701/hazelcast/health/cluster-size)
           # Test the currect number of Hazelcast members
-          test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
+          test ${CLUSTER_SIZE} -eq 3
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -101,7 +101,7 @@ releases:
   name: zeebe-operate-helm
   namespace: jx-staging
 - chart: dev/zeebe-cluster-helm
-  version: 0.0.200
+  version: 0.0.202
   name: zeebe-cluster-helm
   namespace: jx-staging
 - chart: dev/zeebe-zeeqs-helm


### PR DESCRIPTION
chore: promote zeebe-cluster-helm to version 0.0.202 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge