### PR TITLE
chore: promote zeebe-tasklist-helm to version 0.0.8 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-xyfwt-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-xyfwt-test-pod.yaml
@@ -1,8 +1,8 @@
-# Source: zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/test-elasticsearch-health.yaml
+# Source: zeebe-cluster-helm/charts/elasticsearch/templates/test/test-elasticsearch-health.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-full-helm-crmww-test"
+  name: "zeebe-cluster-helm-xyfwt-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-full-helm-xuuln-test"
+    - name: "zeebe-cluster-helm-aaouq-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-full-helm-visyk-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-full-helm-visyk-test-pod.yaml
@@ -1,8 +1,8 @@
-# Source: zeebe-cluster-helm/charts/elasticsearch/templates/test/test-elasticsearch-health.yaml
+# Source: zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/test-elasticsearch-health.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-cluster-helm-xvxjm-test"
+  name: "zeebe-full-helm-visyk-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-cluster-helm-vauta-test"
+    - name: "zeebe-full-helm-wvtmo-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-tasklist-helm/templates/tests/zeebe-tasklist-helm-test-connection-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-tasklist-helm/templates/tests/zeebe-tasklist-helm-test-connection-pod.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "zeebe-tasklist-helm-test-connection"
   labels:
     app.kubernetes.io/name: zeebe-tasklist-helm
-    helm.sh/chart: zeebe-tasklist-helm-0.0.7
+    helm.sh/chart: zeebe-tasklist-helm-0.0.8
     app.kubernetes.io/instance: zeebe-tasklist-helm
     app.kubernetes.io/version: "1.0"
     app.kubernetes.io/managed-by: Helm

--- a/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-0.0.8-release.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-0.0.8-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-01T12:30:09Z"
+  creationTimestamp: "2020-12-01T13:07:38Z"
   deletionTimestamp: null
-  name: 'zeebe-tasklist-helm-0.0.7'
+  name: 'zeebe-tasklist-helm-0.0.8'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -19,7 +19,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: added variables
-      sha: ab561eb9d5a2b316125e3f75ba5b650214bbb60b
+      sha: b18e06dcf520f5895849d1c7486beba60cb29332
     - author:
         email: salaboy@gmail.com
         name: salaboy
@@ -28,22 +28,12 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        adding pipelines
-      sha: c674b0e97b0c68bbc3a8d5cc0776026d3bdb55bf
-    - author:
-        email: salaboy@gmail.com
-        name: salaboy
-      branch: master
-      committer:
-        email: salaboy@gmail.com
-        name: salaboy
-      message: |
-        updating to helm3 and jx3
-      sha: 7c6e2f6f9532ebf77e5bb8e1101d1fcf1ddd9b97
+        replacing repo and tag only at the beggining of a new line
+      sha: 0202ae6bd1aac1271c61f1f84a11dc64c570672c
   gitHttpUrl: https://github.com/zeebe-io/zeebe-tasklist-helm
   gitOwner: zeebe-io
   gitRepository: zeebe-tasklist-helm
   name: 'zeebe-tasklist-helm'
-  releaseNotesURL: https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.7
-  version: v0.0.7
+  releaseNotesURL: https://github.com/zeebe-io/zeebe-tasklist-helm/releases/tag/v0.0.8
+  version: v0.0.8
 status: {}

--- a/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: zeebe-tasklist-helm
-          image: "gcr.io/camunda-researchanddevelopment/zeebe-tasklist-helm:0.0.7"
+          image: "camunda/zeebe-tasklist:SNAPSHOT"
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "dev,dev-data,auth"

--- a/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-ingress.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-tasklist-helm/zeebe-tasklist-helm-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: zeebe-tasklist-helm
   labels:
     app.kubernetes.io/name: zeebe-tasklist-helm
-    helm.sh/chart: zeebe-tasklist-helm-0.0.7
+    helm.sh/chart: zeebe-tasklist-helm-0.0.8
     app.kubernetes.io/instance: zeebe-tasklist-helm
     app.kubernetes.io/version: "1.0"
     app.kubernetes.io/managed-by: Helm

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-nqzm8-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-nqzm8-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-pde6w"
+  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-nqzm8"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-8s46c-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-8s46c-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-test-gku0k"
+  name: "zeebe-zeeqs-helm-hazelcast-test-8s46c"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -109,7 +109,7 @@ releases:
   name: zeebe-zeeqs-helm
   namespace: jx-staging
 - chart: dev/zeebe-tasklist-helm
-  version: 0.0.7
+  version: 0.0.8
   name: zeebe-tasklist-helm
   namespace: jx-staging
 - chart: dev/zeebe-full-helm


### PR DESCRIPTION
chore: promote zeebe-tasklist-helm to version 0.0.8 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge