### PR TITLE
chore: promote zeebe-zeeqs-helm to version 0.0.19 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-vkuyf-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-vkuyf-test-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-cluster-helm-xvxjm-test"
+  name: "zeebe-cluster-helm-vkuyf-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-cluster-helm-vauta-test"
+    - name: "zeebe-cluster-helm-vnaxi-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-full-helm-jxhte-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-full-helm-jxhte-test-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-full-helm-crmww-test"
+  name: "zeebe-full-helm-jxhte-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-full-helm-xuuln-test"
+    - name: "zeebe-full-helm-xlafq-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-lmyj4-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-lmyj4-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-pde6w"
+  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-lmyj4"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-ux5og-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-ux5og-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-test-gku0k"
+  name: "zeebe-zeeqs-helm-hazelcast-test-ux5og"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/templates/tests/zeebe-zeeqs-helm-test-connection-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/templates/tests/zeebe-zeeqs-helm-test-connection-pod.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "zeebe-zeeqs-helm-test-connection"
   labels:
     app.kubernetes.io/name: zeebe-zeeqs-helm
-    helm.sh/chart: zeebe-zeeqs-helm-0.0.18
+    helm.sh/chart: zeebe-zeeqs-helm-0.0.19
     app.kubernetes.io/instance: zeebe-zeeqs-helm
     app.kubernetes.io/version: "1.0"
     app.kubernetes.io/managed-by: Helm

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-0.0.19-release.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-0.0.19-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-01T12:16:28Z"
+  creationTimestamp: "2020-12-01T13:13:59Z"
   deletionTimestamp: null
-  name: 'zeebe-zeeqs-helm-0.0.18'
+  name: 'zeebe-zeeqs-helm-0.0.19'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -19,7 +19,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: added variables
-      sha: 1eb78508facae30902113707f7761648c1d780a0
+      sha: 7f044d2598f3b0201870c2b9de4f759285656b6d
     - author:
         email: salaboy@gmail.com
         name: salaboy
@@ -28,12 +28,22 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        hazelcast own repo
-      sha: d63a429badf088a5a242198f4b1a48dabf09981e
+        touch
+      sha: 321a5249c6760354879402c4631ccf64bbbc6785
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        replacing repo and tag only at the beggining of a new line
+      sha: a89481b33d4221f9b2bb7d3adcbf7eae34f88c4c
   gitHttpUrl: https://github.com/zeebe-io/zeebe-zeeqs-helm
   gitOwner: zeebe-io
   gitRepository: zeebe-zeeqs-helm
   name: 'zeebe-zeeqs-helm'
-  releaseNotesURL: https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.18
-  version: v0.0.18
+  releaseNotesURL: https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.19
+  version: v0.0.19
 status: {}

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: zeebe-zeeqs-helm
-          image: "gcr.io/camunda-researchanddevelopment/zeebe-zeeqs-helm:0.0.18"
+          image: "camunda/zeeqs:latest"
           resources:
             limits:
               cpu: 1000m

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -105,7 +105,7 @@ releases:
   name: zeebe-cluster-helm
   namespace: jx-staging
 - chart: dev/zeebe-zeeqs-helm
-  version: 0.0.18
+  version: 0.0.19
   name: zeebe-zeeqs-helm
   namespace: jx-staging
 - chart: dev/zeebe-tasklist-helm


### PR DESCRIPTION
chore: promote zeebe-zeeqs-helm to version 0.0.19 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge