### PR TITLE
chore: promote zeebe-zeeqs-helm to version 0.0.20 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-zrgip-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-cluster-helm-zrgip-test-pod.yaml
@@ -1,8 +1,8 @@
-# Source: zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/test-elasticsearch-health.yaml
+# Source: zeebe-cluster-helm/charts/elasticsearch/templates/test/test-elasticsearch-health.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-full-helm-visyk-test"
+  name: "zeebe-cluster-helm-zrgip-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-full-helm-wvtmo-test"
+    - name: "zeebe-cluster-helm-grbla-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-full-helm-yosnk-test-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/zeebe-full-helm-yosnk-test-pod.yaml
@@ -1,8 +1,8 @@
-# Source: zeebe-cluster-helm/charts/elasticsearch/templates/test/test-elasticsearch-health.yaml
+# Source: zeebe-full-helm/charts/zeebe-cluster-helm/charts/elasticsearch/templates/test/test-elasticsearch-health.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-cluster-helm-xyfwt-test"
+  name: "zeebe-full-helm-yosnk-test"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -14,7 +14,7 @@ spec:
     fsGroup: 1000
     runAsUser: 1000
   containers:
-    - name: "zeebe-cluster-helm-aaouq-test"
+    - name: "zeebe-full-helm-kzusw-test"
       image: "docker.elastic.co/elasticsearch/elasticsearch:6.8.5"
       imagePullPolicy: "IfNotPresent"
       command:

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-9knsn-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-mancenter-test-9knsn-pod.yaml
@@ -1,8 +1,8 @@
-# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-hazelcast.yaml
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-management-center.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-test-8s46c"
+  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-9knsn"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
@@ -24,17 +24,17 @@ spec:
     runAsUser: 1001
     runAsGroup: 1001
   containers:
-    - name: "zeebe-zeeqs-helm-hazelcast-test"
+    - name: "zeebe-zeeqs-helm-hazelcast-mancenter-test"
       image: "hazelcast/hazelcast:4.1"
       command:
         - "bash"
         - "-c"
         - |
           set -ex
-          # Get the number of Hazelcast members in the cluster
-          CLUSTER_SIZE=$(curl zeebe-zeeqs-helm-hazelcast:5701/hazelcast/health/cluster-size)
+          # Get the HTTP Response Code of the Health Check
+          HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null zeebe-zeeqs-helm-hazelcast-mancenter:8080/health)
           # Test the currect number of Hazelcast members
-          test ${CLUSTER_SIZE} -eq 3
+          test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-rxy4y-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/charts/hazelcast/templates/tests/zeebe-zeeqs-helm-hazelcast-test-rxy4y-pod.yaml
@@ -1,8 +1,8 @@
-# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-management-center.yaml
+# Source: zeebe-zeeqs-helm/charts/hazelcast/templates/tests/test-hazelcast.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zeebe-zeeqs-helm-hazelcast-mancenter-test-nqzm8"
+  name: "zeebe-zeeqs-helm-hazelcast-test-rxy4y"
   annotations:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
@@ -24,17 +24,17 @@ spec:
     runAsUser: 1001
     runAsGroup: 1001
   containers:
-    - name: "zeebe-zeeqs-helm-hazelcast-mancenter-test"
+    - name: "zeebe-zeeqs-helm-hazelcast-test"
       image: "hazelcast/hazelcast:4.1"
       command:
         - "bash"
         - "-c"
         - |
           set -ex
-          # Get the HTTP Response Code of the Health Check
-          HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null zeebe-zeeqs-helm-hazelcast-mancenter:8080/health)
+          # Get the number of Hazelcast members in the cluster
+          CLUSTER_SIZE=$(curl zeebe-zeeqs-helm-hazelcast:5701/hazelcast/health/cluster-size)
           # Test the currect number of Hazelcast members
-          test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
+          test ${CLUSTER_SIZE} -eq 3
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/templates/tests/zeebe-zeeqs-helm-test-connection-pod.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/templates/tests/zeebe-zeeqs-helm-test-connection-pod.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "zeebe-zeeqs-helm-test-connection"
   labels:
     app.kubernetes.io/name: zeebe-zeeqs-helm
-    helm.sh/chart: zeebe-zeeqs-helm-0.0.18
+    helm.sh/chart: zeebe-zeeqs-helm-0.0.20
     app.kubernetes.io/instance: zeebe-zeeqs-helm
     app.kubernetes.io/version: "1.0"
     app.kubernetes.io/managed-by: Helm

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-0.0.20-release.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-0.0.20-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-01T12:16:28Z"
+  creationTimestamp: "2020-12-01T13:14:44Z"
   deletionTimestamp: null
-  name: 'zeebe-zeeqs-helm-0.0.18'
+  name: 'zeebe-zeeqs-helm-0.0.20'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -19,21 +19,11 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: added variables
-      sha: 1eb78508facae30902113707f7761648c1d780a0
-    - author:
-        email: salaboy@gmail.com
-        name: salaboy
-      branch: master
-      committer:
-        email: salaboy@gmail.com
-        name: salaboy
-      message: |
-        hazelcast own repo
-      sha: d63a429badf088a5a242198f4b1a48dabf09981e
+      sha: 07f9a5d3485face76509667294153f65057b33bb
   gitHttpUrl: https://github.com/zeebe-io/zeebe-zeeqs-helm
   gitOwner: zeebe-io
   gitRepository: zeebe-zeeqs-helm
   name: 'zeebe-zeeqs-helm'
-  releaseNotesURL: https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.18
-  version: v0.0.18
+  releaseNotesURL: https://github.com/zeebe-io/zeebe-zeeqs-helm/releases/tag/v0.0.20
+  version: v0.0.20
 status: {}

--- a/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-zeeqs-helm/zeebe-zeeqs-helm-deploy.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: zeebe-zeeqs-helm
-          image: "gcr.io/camunda-researchanddevelopment/zeebe-zeeqs-helm:0.0.18"
+          image: "camunda/zeeqs:latest"
           resources:
             limits:
               cpu: 1000m

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -105,7 +105,7 @@ releases:
   name: zeebe-cluster-helm
   namespace: jx-staging
 - chart: dev/zeebe-zeeqs-helm
-  version: 0.0.18
+  version: 0.0.20
   name: zeebe-zeeqs-helm
   namespace: jx-staging
 - chart: dev/zeebe-tasklist-helm


### PR DESCRIPTION
chore: promote zeebe-zeeqs-helm to version 0.0.20 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge