### PR TITLE
chore: promote cd-flow-backend to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-0.0.2-release.yaml
@@ -1,0 +1,129 @@
+# Source: cd-flow-backend/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-07T17:38:04Z"
+  deletionTimestamp: null
+  name: 'cd-flow-backend-0.0.2'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.2
+      sha: 7ece594e2f611ca9fa1dca93cf3aff0c11c7fbf7
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 360bb117ece9b1d3d7f50e227e8e6e601647ce2b
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        using milestone
+      sha: cdd1ed9be793eda2d0c4cc77f598b6d0124bc84a
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        touching
+      sha: 9a674aef821a50c29f256b010a19bb8c629ac577
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        touch again
+      sha: 245c3617abe68312388666798b6f7acb727ab6f1
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        touch again
+      sha: 3836d896d58bfd20e64e567e2aad73546d6bb729
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        touch
+      sha: 93b7303fcca3a7dc236d9a00fad2b83045aff920
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        fix(plugins): use a better version of maven plugins
+      sha: 34903ac55f7fdc6d13359231e6ebfb1d47ca753a
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        chore: Jenkins X build pack
+      sha: 0f08e22ae748a1b7e9e50333ef66e2f6dee4a961
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        add projects endpoint
+      sha: 68b8500f9ac529815910cd4bc4233741654f300e
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        initial commit
+      sha: e85365a896f565f5f9c2896794f1970c78cdf5f6
+  gitHttpUrl: https://github.com/salaboy/cd-flow-backend
+  gitOwner: salaboy
+  gitRepository: cd-flow-backend
+  name: 'cd-flow-backend'
+  releaseNotesURL: https://github.com/salaboy/cd-flow-backend/releases/tag/v0.0.2
+  version: v0.0.2
+status: {}

--- a/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-cd-flow-backend-deploy.yaml
+++ b/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-cd-flow-backend-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: cd-flow-backend/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cd-flow-backend-cd-flow-backend
+  labels:
+    draft: draft-app
+    chart: "cd-flow-backend-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: cd-flow-backend-cd-flow-backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: cd-flow-backend-cd-flow-backend
+    spec:
+      serviceAccountName: cd-flow-backend-cd-flow-backend
+      containers:
+        - name: cd-flow-backend
+          image: "gcr.io/camunda-researchanddevelopment/cd-flow-backend:0.0.2"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.2
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-cd-flow-backend-sa.yaml
+++ b/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-cd-flow-backend-sa.yaml
@@ -1,0 +1,8 @@
+# Source: cd-flow-backend/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cd-flow-backend-cd-flow-backend
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-ingress.yaml
+++ b/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: cd-flow-backend/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: cd-flow-backend
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: cd-flow-backend
+              servicePort: 80
+      host: cd-flow-backend-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-svc.yaml
+++ b/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-svc.yaml
@@ -1,0 +1,21 @@
+# Source: cd-flow-backend/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cd-flow-backend
+  labels:
+    chart: "cd-flow-backend-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: cd-flow-backend-cd-flow-backend

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -105,4 +105,4 @@ releases:
   name: cd-flow-backend
   namespace: jx-staging
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -100,5 +100,9 @@ releases:
   version: 0.1.1
   name: cd-flow-ui
   namespace: jx-staging
+- chart: dev/cd-flow-backend
+  version: 0.0.2
+  name: cd-flow-backend
+  namespace: jx-staging
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}


### PR DESCRIPTION
chore: promote cd-flow-backend to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge