### PR TITLE
chore: promote fmtok8s-agenda-rest to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-ingress.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-agenda-rest/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-agenda
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-agenda
+              servicePort: 80
+      host: fmtok8s-agenda-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.5-release.yaml
@@ -1,0 +1,52 @@
+# Source: fmtok8s-agenda-rest/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-11T10:09:14Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-agenda-rest-0.0.5'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      message: |
+        release 0.0.5
+      sha: 20558062a00b1fcf2674dd50a67d19301eac14f6
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        updating service info and removing target
+      sha: eb3b25e9953a9edc9759e983de537d00347afb17
+  gitCloneUrl: https://github.com/salaboy/fmtok8s-agenda-rest.git
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-agenda-rest
+  gitOwner: salaboy
+  gitRepository: fmtok8s-agenda-rest
+  name: 'fmtok8s-agenda-rest'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-agenda-rest/releases/tag/v0.0.5
+  version: v0.0.5
+status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
@@ -1,0 +1,69 @@
+# Source: fmtok8s-agenda-rest/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-agenda-rest-0.0.5"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+    spec:
+      containers:
+        - name: fmtok8s-agenda-rest
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-agenda-rest:0.0.5"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.5
+            - name: POD_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1768Mi
+            requests:
+              cpu: 650m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-agenda-rest/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-agenda
+  labels:
+    chart: "fmtok8s-agenda-rest-0.0.5"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-agenda-rest-fmtok8s-agenda-rest

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -96,5 +96,9 @@ releases:
   version: 0.0.3
   name: cd-flow-backend
   namespace: jx-staging
+- chart: dev/fmtok8s-agenda-rest
+  version: 0.0.5
+  name: fmtok8s-agenda-rest
+  namespace: jx-staging
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -101,4 +101,4 @@ releases:
   name: fmtok8s-agenda-rest
   namespace: jx-staging
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-agenda-rest to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge