### PR TITLE
chore: promote cd-flow-backend to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-0.0.5-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-15T10:16:40Z"
+  creationTimestamp: "2021-01-15T11:07:59Z"
   deletionTimestamp: null
-  name: 'cd-flow-backend-0.0.4'
+  name: 'cd-flow-backend-0.0.5'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.4
-      sha: 4cd87047cb35fa096e0d79ed39b887e31ebcc373
+        chore: release 0.0.5
+      sha: a7c15618011aa9d4f00eb6dc6e5827c63a027376
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: acf561f7c18a492d2f9e1ec9ddc26d0c5c740e36
+      sha: ac7885a641b25b63bde277e816acc2f9c7fdd338
     - author:
         email: salaboy@gmail.com
         name: salaboy
@@ -38,12 +38,12 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        adding metrics
-      sha: 721ce5e4d6b7fee043d924413afe41e4c2f02726
+        returning session to client
+      sha: 57179bd6b2e51c486699385bc36886096513fbd1
   gitHttpUrl: https://github.com/salaboy/cd-flow-backend
   gitOwner: salaboy
   gitRepository: cd-flow-backend
   name: 'cd-flow-backend'
-  releaseNotesURL: https://github.com/salaboy/cd-flow-backend/releases/tag/v0.0.4
-  version: v0.0.4
+  releaseNotesURL: https://github.com/salaboy/cd-flow-backend/releases/tag/v0.0.5
+  version: v0.0.5
 status: {}

--- a/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-cd-flow-backend-deploy.yaml
+++ b/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-cd-flow-backend-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cd-flow-backend-cd-flow-backend
   labels:
     draft: draft-app
-    chart: "cd-flow-backend-0.0.4"
+    chart: "cd-flow-backend-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: cd-flow-backend-cd-flow-backend
       containers:
         - name: cd-flow-backend
-          image: "gcr.io/camunda-researchanddevelopment/cd-flow-backend:0.0.4"
+          image: "gcr.io/camunda-researchanddevelopment/cd-flow-backend:0.0.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.5
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-svc.yaml
+++ b/config-root/namespaces/jx-staging/cd-flow-backend/cd-flow-backend-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: cd-flow-backend
   labels:
-    chart: "cd-flow-backend-0.0.4"
+    chart: "cd-flow-backend-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -93,7 +93,7 @@ releases:
   values:
   - versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
 - chart: dev/cd-flow-backend
-  version: 0.0.4
+  version: 0.0.5
   name: cd-flow-backend
   namespace: jx-staging
 - chart: dev/fmtok8s-agenda-rest
@@ -101,4 +101,4 @@ releases:
   name: fmtok8s-agenda-rest
   namespace: jx-staging
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -101,4 +101,4 @@ releases:
   name: fmtok8s-agenda-rest
   namespace: jx-staging
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""


### PR DESCRIPTION
chore: promote cd-flow-backend to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge