### PR TITLE
chore: promote cd-flow-backend to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-production/cd-flow-backend/backend-ingress.yaml
+++ b/config-root/namespaces/jx-production/cd-flow-backend/backend-ingress.yaml
@@ -1,0 +1,16 @@
+# Source: cd-flow-backend/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: backend
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            backend:
+              serviceName: cd-flow-backend
+              servicePort: 80

--- a/config-root/namespaces/jx-production/cd-flow-backend/cd-flow-backend-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-production/cd-flow-backend/cd-flow-backend-0.0.5-release.yaml
@@ -1,0 +1,49 @@
+# Source: cd-flow-backend/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-15T11:07:59Z"
+  deletionTimestamp: null
+  name: 'cd-flow-backend-0.0.5'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.5
+      sha: a7c15618011aa9d4f00eb6dc6e5827c63a027376
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: ac7885a641b25b63bde277e816acc2f9c7fdd338
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        returning session to client
+      sha: 57179bd6b2e51c486699385bc36886096513fbd1
+  gitHttpUrl: https://github.com/salaboy/cd-flow-backend
+  gitOwner: salaboy
+  gitRepository: cd-flow-backend
+  name: 'cd-flow-backend'
+  releaseNotesURL: https://github.com/salaboy/cd-flow-backend/releases/tag/v0.0.5
+  version: v0.0.5
+status: {}

--- a/config-root/namespaces/jx-production/cd-flow-backend/cd-flow-backend-cd-flow-backend-deploy.yaml
+++ b/config-root/namespaces/jx-production/cd-flow-backend/cd-flow-backend-cd-flow-backend-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: cd-flow-backend/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cd-flow-backend-cd-flow-backend
+  labels:
+    draft: draft-app
+    chart: "cd-flow-backend-0.0.5"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: cd-flow-backend-cd-flow-backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: cd-flow-backend-cd-flow-backend
+    spec:
+      serviceAccountName: cd-flow-backend-cd-flow-backend
+      containers:
+        - name: cd-flow-backend
+          image: "gcr.io/camunda-researchanddevelopment/cd-flow-backend:0.0.5"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.5
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1500m
+              memory: 1768Mi
+            requests:
+              cpu: 750m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/cd-flow-backend/cd-flow-backend-cd-flow-backend-sa.yaml
+++ b/config-root/namespaces/jx-production/cd-flow-backend/cd-flow-backend-cd-flow-backend-sa.yaml
@@ -1,0 +1,8 @@
+# Source: cd-flow-backend/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cd-flow-backend-cd-flow-backend
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/cd-flow-backend/cd-flow-backend-svc.yaml
+++ b/config-root/namespaces/jx-production/cd-flow-backend/cd-flow-backend-svc.yaml
@@ -1,0 +1,21 @@
+# Source: cd-flow-backend/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cd-flow-backend
+  labels:
+    chart: "cd-flow-backend-0.0.5"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: cd-flow-backend-cd-flow-backend

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -100,5 +100,9 @@ releases:
   version: 0.0.5
   name: fmtok8s-agenda-rest
   namespace: jx-staging
+- chart: dev/cd-flow-backend
+  version: 0.0.5
+  name: cd-flow-backend
+  namespace: jx-production
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -105,4 +105,4 @@ releases:
   name: cd-flow-backend
   namespace: jx-production
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""


### PR DESCRIPTION
chore: promote cd-flow-backend to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge