### PR TITLE
chore: promote fmtok8s-agenda-rest to version 0.0.6

### DIFF
--- a/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-ingress.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-agenda-rest/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-agenda
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-agenda
+              servicePort: 80
+      host: fmtok8s-agenda-jx-production.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.6-release.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.6-release.yaml
@@ -1,0 +1,69 @@
+# Source: fmtok8s-agenda-rest/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-20T09:17:10Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-agenda-rest-0.0.6'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.6
+      sha: 1da7665e37785a23263c865c9c0860512aec4c4d
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 21b114eefac7d96df8487e875b94aef84a3c7449
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        update charts (https://github.com/jenkins-x/jx3-gitops-template) from master (32e5b38dc265781b9d14c777c88f88a0a948bfb0) to master (cd501cf5c185c592663d68273b60e3413c0278fb)
+      sha: 0442f90dd5349c81f69e9037e5ab66ba6ef97998
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        update jenkins-x (https://github.com/jenkins-x/jx3-pipeline-catalog) from master (bc0d365dd4a8dc164fe65fb1539c87503d78fe3f) to master (1d39235ee9235d7d52d4025a8e59cb8bda04306a)
+      sha: f8e6a30d7be5156b6f3b863c55e10f4b40762be6
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        adding env vars for knative
+      sha: 0c2f24fe2b8755910757b0cbd082fb8924ca0e28
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-agenda-rest
+  gitOwner: salaboy
+  gitRepository: fmtok8s-agenda-rest
+  name: 'fmtok8s-agenda-rest'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-agenda-rest/releases/tag/v0.0.6
+  version: v0.0.6
+status: {}

--- a/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
@@ -1,0 +1,70 @@
+# Source: fmtok8s-agenda-rest/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-agenda-rest-0.0.6"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+    spec:
+      serviceAccountName: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+      containers:
+        - name: fmtok8s-agenda-rest
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-agenda-rest:0.0.6"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.6
+            - name: POD_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1768Mi
+            requests:
+              cpu: 650m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-sa.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-sa.yaml
@@ -1,0 +1,8 @@
+# Source: fmtok8s-agenda-rest/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-agenda-rest/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-agenda
+  labels:
+    chart: "fmtok8s-agenda-rest-0.0.6"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-agenda-rest-fmtok8s-agenda-rest

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -107,4 +107,4 @@ releases:
   name: fmtok8s-agenda-rest
   namespace: jx-production
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -21,6 +21,8 @@ repositories:
   url: https://charts.helm.sh/stable
 - name: dev
   url: http://chartmuseum-jx.35.222.17.41.nip.io/
+- name: dev2
+  url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: jenkins-x/jxboot-helmfile-resources
   version: 1.0.16
@@ -100,5 +102,9 @@ releases:
   version: 0.0.5
   name: fmtok8s-agenda-rest
   namespace: jx-staging
+- chart: dev2/fmtok8s-agenda-rest
+  version: 0.0.6
+  name: fmtok8s-agenda-rest
+  namespace: jx-production
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}


### PR DESCRIPTION
chore: promote fmtok8s-agenda-rest to version 0.0.6

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
