### PR TITLE
chore: promote fmtok8s-email-rest to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-ingress.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-email-rest/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-email
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-email
+              servicePort: 80
+      host: fmtok8s-email-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-0.0.5-release.yaml
@@ -1,0 +1,68 @@
+# Source: fmtok8s-email-rest/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-20T10:18:57Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-email-rest-0.0.5'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: salaboy
+      message: |
+        release 0.0.5
+      sha: 81a07ed93e62b63fea839ffd947ad89d80bd75e6
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        updating email service
+      sha: 874489c35063e093750ff657e4379744769881b4
+    - author:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        accountReference:
+          - id: salaboy-2
+            provider: jenkins.io/git-github-userid
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        adding pod, worker, ns and new info controller
+      sha: dfb17cebe65408d955be970dbde800611f933c42
+  gitCloneUrl: https://github.com/salaboy/fmtok8s-email-rest.git
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-email-rest
+  gitOwner: salaboy
+  gitRepository: fmtok8s-email-rest
+  name: 'fmtok8s-email-rest'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-email-rest/releases/tag/v0.0.5
+  version: v0.0.5
+status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-deploy.yaml
@@ -1,0 +1,69 @@
+# Source: fmtok8s-email-rest/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-email-rest-fmtok8s-email-rest
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-email-rest-0.0.5"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-email-rest-fmtok8s-email-rest
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-email-rest-fmtok8s-email-rest
+    spec:
+      containers:
+        - name: fmtok8s-email-rest
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-email-rest:0.0.5"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.5
+            - name: POD_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1768Mi
+            requests:
+              cpu: 650m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-email-rest/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-email
+  labels:
+    chart: "fmtok8s-email-rest-0.0.5"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-email-rest-fmtok8s-email-rest

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -106,5 +106,9 @@ releases:
   version: 0.0.11
   name: fmtok8s-c4p-rest
   namespace: jx-staging
+- chart: dev2/fmtok8s-email-rest
+  version: 0.0.5
+  name: fmtok8s-email-rest
+  namespace: jx-staging
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -111,4 +111,4 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-staging
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-email-rest to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
