### PR TITLE
chore: promote fmtok8s-email-rest to version 0.0.6

### DIFF
--- a/config-root/namespaces/jx-production/fmtok8s-email-rest/fmtok8s-email-ingress.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-email-rest/fmtok8s-email-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-email-rest/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-email
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-email
+              servicePort: 80
+      host: fmtok8s-email-jx-production.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-production/fmtok8s-email-rest/fmtok8s-email-rest-0.0.6-release.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-email-rest/fmtok8s-email-rest-0.0.6-release.yaml
@@ -1,0 +1,59 @@
+# Source: fmtok8s-email-rest/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-20T10:25:35Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-email-rest-0.0.6'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.6
+      sha: 42b0dbb73c61bff7d852b16e8b253beae5e7f09d
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 0be02d3ac6ae2ab823977be6835c679da44dd5d4
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        update charts (https://github.com/jenkins-x/jx3-gitops-template) from master (32e5b38dc265781b9d14c777c88f88a0a948bfb0) to master (cd501cf5c185c592663d68273b60e3413c0278fb)
+      sha: e7ee51d59dbcfea95529ad1e239585a997d80a49
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        update jenkins-x (https://github.com/jenkins-x/jx3-pipeline-catalog) from master (bc0d365dd4a8dc164fe65fb1539c87503d78fe3f) to master (0f4869deab149e13d1fbb948f70e8e68513ecd96)
+      sha: a89aaa431b904a46ed2cc96d7728b0ab9b48e09b
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-email-rest
+  gitOwner: salaboy
+  gitRepository: fmtok8s-email-rest
+  name: 'fmtok8s-email-rest'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-email-rest/releases/tag/v0.0.6
+  version: v0.0.6
+status: {}

--- a/config-root/namespaces/jx-production/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-deploy.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-deploy.yaml
@@ -1,0 +1,70 @@
+# Source: fmtok8s-email-rest/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-email-rest-fmtok8s-email-rest
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-email-rest-0.0.6"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-email-rest-fmtok8s-email-rest
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-email-rest-fmtok8s-email-rest
+    spec:
+      serviceAccountName: fmtok8s-email-rest-fmtok8s-email-rest
+      containers:
+        - name: fmtok8s-email-rest
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-email-rest:0.0.6"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.6
+            - name: POD_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1768Mi
+            requests:
+              cpu: 650m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-sa.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-sa.yaml
@@ -1,0 +1,8 @@
+# Source: fmtok8s-email-rest/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fmtok8s-email-rest-fmtok8s-email-rest
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/fmtok8s-email-rest/fmtok8s-email-svc.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-email-rest/fmtok8s-email-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-email-rest/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-email
+  labels:
+    chart: "fmtok8s-email-rest-0.0.6"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-email-rest-fmtok8s-email-rest

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -115,4 +115,4 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-production
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -110,5 +110,9 @@ releases:
   version: 0.0.5
   name: fmtok8s-email-rest
   namespace: jx-staging
+- chart: dev2/fmtok8s-email-rest
+  version: 0.0.6
+  name: fmtok8s-email-rest
+  namespace: jx-production
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}


### PR DESCRIPTION
chore: promote fmtok8s-email-rest to version 0.0.6

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
