### PR TITLE
chore: promote fmtok8s-c4p-rest to version 0.0.12

### DIFF
--- a/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-ingress.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-c4p-rest/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-c4p
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-c4p
+              servicePort: 80
+      host: fmtok8s-c4p-jx-production.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.12-release.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.12-release.yaml
@@ -1,0 +1,49 @@
+# Source: fmtok8s-c4p-rest/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-20T14:54:00Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-c4p-rest-0.0.12'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.12
+      sha: b73780741f9d1310f79edd7a933ccf647e246b17
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 9c566e6a6d563c1d9ec54dc0391b707aea0f1565
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        adding mysql driver
+      sha: 898aec1ee9927ab1d9978f72142f3b6d1be71554
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-c4p-rest
+  gitOwner: salaboy
+  gitRepository: fmtok8s-c4p-rest
+  name: 'fmtok8s-c4p-rest'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p-rest/releases/tag/v0.0.12
+  version: v0.0.12
+status: {}

--- a/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
@@ -1,0 +1,70 @@
+# Source: fmtok8s-c4p-rest/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-c4p-rest-fmtok8s-c4p-rest
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-c4p-rest-0.0.12"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-c4p-rest-fmtok8s-c4p-rest
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-c4p-rest-fmtok8s-c4p-rest
+    spec:
+      serviceAccountName: fmtok8s-c4p-rest-fmtok8s-c4p-rest
+      containers:
+        - name: fmtok8s-c4p-rest
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p-rest:0.0.12"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.12
+            - name: POD_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1768Mi
+            requests:
+              cpu: 650m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-sa.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-sa.yaml
@@ -1,0 +1,8 @@
+# Source: fmtok8s-c4p-rest/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fmtok8s-c4p-rest-fmtok8s-c4p-rest
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-c4p-rest/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-c4p
+  labels:
+    chart: "fmtok8s-c4p-rest-0.0.12"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-c4p-rest-fmtok8s-c4p-rest

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -115,4 +115,4 @@ releases:
   name: fmtok8s-c4p-rest
   namespace: jx-production
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -110,5 +110,9 @@ releases:
   version: 0.0.6
   name: fmtok8s-email-rest
   namespace: jx-staging
+- chart: dev2/fmtok8s-c4p-rest
+  version: 0.0.12
+  name: fmtok8s-c4p-rest
+  namespace: jx-production
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}


### PR DESCRIPTION
chore: promote fmtok8s-c4p-rest to version 0.0.12

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
