### PR TITLE
chore: promote fmtok8s-email-rest to version 0.0.8

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-0.0.8-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-0.0.8-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-21T18:17:32Z"
+  creationTimestamp: "2021-01-22T13:43:22Z"
   deletionTimestamp: null
-  name: 'fmtok8s-email-rest-0.0.7'
+  name: 'fmtok8s-email-rest-0.0.8'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.7
-      sha: 8eb77c1c7c030dee54fbd306bd881a8d8a98b34d
+        chore: release 0.0.8
+      sha: 5f59a305f230ba4e16b9c78027818228236dc933
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: c071d4c09227354d87807a6e319767993b1711d4
+      sha: f8449eb49ca2ba1236f5c9f6eed87c7698dc41b5
     - author:
         email: salaboy@gmail.com
         name: salaboy
@@ -38,12 +38,12 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        adding prometheus metrics collector
-      sha: 36fdf13a8982b5ce3e079691ebc010140e09d09f
+        adding opentracing jaeger
+      sha: e5aa01073fae68429947eefd93e74213f99dd9c4
   gitHttpUrl: https://github.com/salaboy/fmtok8s-email-rest
   gitOwner: salaboy
   gitRepository: fmtok8s-email-rest
   name: 'fmtok8s-email-rest'
-  releaseNotesURL: https://github.com/salaboy/fmtok8s-email-rest/releases/tag/v0.0.7
-  version: v0.0.7
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-email-rest/releases/tag/v0.0.8
+  version: v0.0.8
 status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-rest-fmtok8s-email-rest-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fmtok8s-email-rest-fmtok8s-email-rest
   labels:
     draft: draft-app
-    chart: "fmtok8s-email-rest-0.0.7"
+    chart: "fmtok8s-email-rest-0.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: fmtok8s-email-rest-fmtok8s-email-rest
       containers:
         - name: fmtok8s-email-rest
-          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-email-rest:0.0.7"
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-email-rest:0.0.8"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.7
+              value: 0.0.8
             - name: POD_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-email-rest/fmtok8s-email-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: fmtok8s-email
   labels:
-    chart: "fmtok8s-email-rest-0.0.7"
+    chart: "fmtok8s-email-rest-0.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -107,8 +107,8 @@ releases:
   name: fmtok8s-c4p-rest
   namespace: jx-staging
 - chart: dev2/fmtok8s-email-rest
-  version: 0.0.7
+  version: 0.0.8
   name: fmtok8s-email-rest
   namespace: jx-staging
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -111,4 +111,4 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-staging
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-email-rest to version 0.0.8

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
