### PR TITLE
chore: promote fmtok8s-agenda-rest to version 0.0.9

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.9-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.9-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-21T18:25:50Z"
+  creationTimestamp: "2021-01-23T10:48:53Z"
   deletionTimestamp: null
-  name: 'fmtok8s-agenda-rest-0.0.8'
+  name: 'fmtok8s-agenda-rest-0.0.9'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.8
-      sha: ad28e56ef05c60e7ad7e63d0d56d498ade500b6c
+        chore: release 0.0.9
+      sha: b9b0a7a69e1bcbfce07da7efea10d8a996fdf8e8
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: cd088d5a83baa3876a4530917d228d126f3b605f
+      sha: 90dba683ab0cde7fe52f74bba5b2bd8b4985c506
     - author:
         email: salaboy@gmail.com
         name: salaboy
@@ -38,12 +38,12 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        adding prometheus metrics collector
-      sha: 8a4062523d04dde6d121cca50eade55759ef1aba
+        adding jaeger and spring boot name
+      sha: 359956a3bfc3582dfdcbd5c150d69db598938741
   gitHttpUrl: https://github.com/salaboy/fmtok8s-agenda-rest
   gitOwner: salaboy
   gitRepository: fmtok8s-agenda-rest
   name: 'fmtok8s-agenda-rest'
-  releaseNotesURL: https://github.com/salaboy/fmtok8s-agenda-rest/releases/tag/v0.0.8
-  version: v0.0.8
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-agenda-rest/releases/tag/v0.0.9
+  version: v0.0.9
 status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fmtok8s-agenda-rest-fmtok8s-agenda-rest
   labels:
     draft: draft-app
-    chart: "fmtok8s-agenda-rest-0.0.8"
+    chart: "fmtok8s-agenda-rest-0.0.9"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: fmtok8s-agenda-rest-fmtok8s-agenda-rest
       containers:
         - name: fmtok8s-agenda-rest
-          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-agenda-rest:0.0.8"
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-agenda-rest:0.0.9"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.8
+              value: 0.0.9
             - name: POD_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: fmtok8s-agenda
   labels:
-    chart: "fmtok8s-agenda-rest-0.0.8"
+    chart: "fmtok8s-agenda-rest-0.0.9"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -99,7 +99,7 @@ releases:
   name: cd-flow-backend
   namespace: jx-staging
 - chart: dev/fmtok8s-agenda-rest
-  version: 0.0.8
+  version: 0.0.9
   name: fmtok8s-agenda-rest
   namespace: jx-staging
 - chart: dev2/fmtok8s-c4p-rest
@@ -111,4 +111,4 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-staging
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -111,4 +111,4 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-staging
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-agenda-rest to version 0.0.9

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
