### PR TITLE
chore: promote fmtok8s-agenda-rest to version 0.0.9

### DIFF
--- a/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-ingress.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-agenda-rest/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-agenda
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-agenda
+              servicePort: 80
+      host: fmtok8s-agenda-jx-production.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.9-release.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-0.0.9-release.yaml
@@ -1,0 +1,49 @@
+# Source: fmtok8s-agenda-rest/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-23T10:48:53Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-agenda-rest-0.0.9'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.9
+      sha: b9b0a7a69e1bcbfce07da7efea10d8a996fdf8e8
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 90dba683ab0cde7fe52f74bba5b2bd8b4985c506
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        adding jaeger and spring boot name
+      sha: 359956a3bfc3582dfdcbd5c150d69db598938741
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-agenda-rest
+  gitOwner: salaboy
+  gitRepository: fmtok8s-agenda-rest
+  name: 'fmtok8s-agenda-rest'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-agenda-rest/releases/tag/v0.0.9
+  version: v0.0.9
+status: {}

--- a/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-deploy.yaml
@@ -1,0 +1,70 @@
+# Source: fmtok8s-agenda-rest/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-agenda-rest-0.0.9"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+    spec:
+      serviceAccountName: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+      containers:
+        - name: fmtok8s-agenda-rest
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-agenda-rest:0.0.9"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.9
+            - name: POD_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1768Mi
+            requests:
+              cpu: 650m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-sa.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-rest-fmtok8s-agenda-rest-sa.yaml
@@ -1,0 +1,8 @@
+# Source: fmtok8s-agenda-rest/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fmtok8s-agenda-rest-fmtok8s-agenda-rest
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-agenda-rest/fmtok8s-agenda-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-agenda-rest/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-agenda
+  labels:
+    chart: "fmtok8s-agenda-rest-0.0.9"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-agenda-rest-fmtok8s-agenda-rest

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -115,4 +115,4 @@ releases:
   name: fmtok8s-agenda-rest
   namespace: jx-production
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -110,5 +110,9 @@ releases:
   version: 0.0.9
   name: fmtok8s-email-rest
   namespace: jx-staging
+- chart: dev2/fmtok8s-agenda-rest
+  version: 0.0.9
+  name: fmtok8s-agenda-rest
+  namespace: jx-production
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}


### PR DESCRIPTION
chore: promote fmtok8s-agenda-rest to version 0.0.9

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
