### PR TITLE
chore: promote fmtok8s-c4p-rest to version 0.0.16

### DIFF
--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.16-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.16-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-24T12:56:02Z"
+  creationTimestamp: "2021-01-25T08:54:07Z"
   deletionTimestamp: null
-  name: 'fmtok8s-c4p-rest-0.0.15'
+  name: 'fmtok8s-c4p-rest-0.0.16'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.15
-      sha: 7bfa1bd47bb7256f33073f3516f8cbb7f8384d56
+        chore: release 0.0.16
+      sha: bc8e46c5588e54e73814e8d230f2b65567b470ef
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 655a30e3d4e4683e950050dc62a752443727567d
+      sha: f4197b40da12fabec5d5780e4e993eb735e32088
     - author:
         email: salaboy@gmail.com
         name: salaboy
@@ -38,22 +38,12 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        using webclient.. removing rest template
-      sha: f2f8dcdbf1857fffdc11766f522d4195201bb2cd
-    - author:
-        email: salaboy@gmail.com
-        name: salaboy
-      branch: master
-      committer:
-        email: salaboy@gmail.com
-        name: salaboy
-      message: |
-        autowiring resttempalte to propagate span for opentracing
-      sha: 91574d73080282abeaf7bda18d05f599d76fd5ad
+        injecting span filter to webclient
+      sha: 45bf9f862c30852b15031b3d31912bc4f3190756
   gitHttpUrl: https://github.com/salaboy/fmtok8s-c4p-rest
   gitOwner: salaboy
   gitRepository: fmtok8s-c4p-rest
   name: 'fmtok8s-c4p-rest'
-  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p-rest/releases/tag/v0.0.15
-  version: v0.0.15
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p-rest/releases/tag/v0.0.16
+  version: v0.0.16
 status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fmtok8s-c4p-rest-fmtok8s-c4p-rest
   labels:
     draft: draft-app
-    chart: "fmtok8s-c4p-rest-0.0.15"
+    chart: "fmtok8s-c4p-rest-0.0.16"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: fmtok8s-c4p-rest-fmtok8s-c4p-rest
       containers:
         - name: fmtok8s-c4p-rest
-          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p-rest:0.0.15"
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p-rest:0.0.16"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.15
+              value: 0.0.16
             - name: POD_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: fmtok8s-c4p
   labels:
-    chart: "fmtok8s-c4p-rest-0.0.15"
+    chart: "fmtok8s-c4p-rest-0.0.16"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -103,7 +103,7 @@ releases:
   name: fmtok8s-agenda-rest
   namespace: jx-staging
 - chart: dev2/fmtok8s-c4p-rest
-  version: 0.0.15
+  version: 0.0.16
   name: fmtok8s-c4p-rest
   namespace: jx-staging
 - chart: dev2/fmtok8s-email-rest
@@ -111,4 +111,4 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-staging
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -111,4 +111,4 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-staging
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-c4p-rest to version 0.0.16

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
