### PR TITLE
chore: promote fmtok8s-c4p-rest to version 0.0.16

### DIFF
--- a/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-ingress.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: fmtok8s-c4p-rest/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: fmtok8s-c4p
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: fmtok8s-c4p
+              servicePort: 80
+      host: fmtok8s-c4p-jx-production.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.16-release.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.16-release.yaml
@@ -1,0 +1,49 @@
+# Source: fmtok8s-c4p-rest/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-25T08:54:07Z"
+  deletionTimestamp: null
+  name: 'fmtok8s-c4p-rest-0.0.16'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.16
+      sha: bc8e46c5588e54e73814e8d230f2b65567b470ef
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: f4197b40da12fabec5d5780e4e993eb735e32088
+    - author:
+        email: salaboy@gmail.com
+        name: salaboy
+      branch: master
+      committer:
+        email: salaboy@gmail.com
+        name: salaboy
+      message: |
+        injecting span filter to webclient
+      sha: 45bf9f862c30852b15031b3d31912bc4f3190756
+  gitHttpUrl: https://github.com/salaboy/fmtok8s-c4p-rest
+  gitOwner: salaboy
+  gitRepository: fmtok8s-c4p-rest
+  name: 'fmtok8s-c4p-rest'
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p-rest/releases/tag/v0.0.16
+  version: v0.0.16
+status: {}

--- a/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
@@ -1,0 +1,70 @@
+# Source: fmtok8s-c4p-rest/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fmtok8s-c4p-rest-fmtok8s-c4p-rest
+  labels:
+    draft: draft-app
+    chart: "fmtok8s-c4p-rest-0.0.16"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: fmtok8s-c4p-rest-fmtok8s-c4p-rest
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: fmtok8s-c4p-rest-fmtok8s-c4p-rest
+    spec:
+      serviceAccountName: fmtok8s-c4p-rest-fmtok8s-c4p-rest
+      containers:
+        - name: fmtok8s-c4p-rest
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p-rest:0.0.16"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.16
+            - name: POD_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1768Mi
+            requests:
+              cpu: 650m
+              memory: 1024Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-sa.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-sa.yaml
@@ -1,0 +1,8 @@
+# Source: fmtok8s-c4p-rest/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fmtok8s-c4p-rest-fmtok8s-c4p-rest
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
+++ b/config-root/namespaces/jx-production/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
@@ -1,0 +1,21 @@
+# Source: fmtok8s-c4p-rest/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: fmtok8s-c4p
+  labels:
+    chart: "fmtok8s-c4p-rest-0.0.16"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: fmtok8s-c4p-rest-fmtok8s-c4p-rest

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.16-release.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-0.0.16-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-24T12:56:02Z"
+  creationTimestamp: "2021-01-25T08:54:07Z"
   deletionTimestamp: null
-  name: 'fmtok8s-c4p-rest-0.0.15'
+  name: 'fmtok8s-c4p-rest-0.0.16'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.15
-      sha: 7bfa1bd47bb7256f33073f3516f8cbb7f8384d56
+        chore: release 0.0.16
+      sha: bc8e46c5588e54e73814e8d230f2b65567b470ef
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 655a30e3d4e4683e950050dc62a752443727567d
+      sha: f4197b40da12fabec5d5780e4e993eb735e32088
     - author:
         email: salaboy@gmail.com
         name: salaboy
@@ -38,22 +38,12 @@ spec:
         email: salaboy@gmail.com
         name: salaboy
       message: |
-        using webclient.. removing rest template
-      sha: f2f8dcdbf1857fffdc11766f522d4195201bb2cd
-    - author:
-        email: salaboy@gmail.com
-        name: salaboy
-      branch: master
-      committer:
-        email: salaboy@gmail.com
-        name: salaboy
-      message: |
-        autowiring resttempalte to propagate span for opentracing
-      sha: 91574d73080282abeaf7bda18d05f599d76fd5ad
+        injecting span filter to webclient
+      sha: 45bf9f862c30852b15031b3d31912bc4f3190756
   gitHttpUrl: https://github.com/salaboy/fmtok8s-c4p-rest
   gitOwner: salaboy
   gitRepository: fmtok8s-c4p-rest
   name: 'fmtok8s-c4p-rest'
-  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p-rest/releases/tag/v0.0.15
-  version: v0.0.15
+  releaseNotesURL: https://github.com/salaboy/fmtok8s-c4p-rest/releases/tag/v0.0.16
+  version: v0.0.16
 status: {}

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-rest-fmtok8s-c4p-rest-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fmtok8s-c4p-rest-fmtok8s-c4p-rest
   labels:
     draft: draft-app
-    chart: "fmtok8s-c4p-rest-0.0.15"
+    chart: "fmtok8s-c4p-rest-0.0.16"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: fmtok8s-c4p-rest-fmtok8s-c4p-rest
       containers:
         - name: fmtok8s-c4p-rest
-          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p-rest:0.0.15"
+          image: "gcr.io/camunda-researchanddevelopment/fmtok8s-c4p-rest:0.0.16"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.15
+              value: 0.0.16
             - name: POD_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
+++ b/config-root/namespaces/jx-staging/fmtok8s-c4p-rest/fmtok8s-c4p-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: fmtok8s-c4p
   labels:
-    chart: "fmtok8s-c4p-rest-0.0.15"
+    chart: "fmtok8s-c4p-rest-0.0.16"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -115,4 +115,4 @@ releases:
   name: fmtok8s-c4p-rest
   namespace: jx-production
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -103,7 +103,7 @@ releases:
   name: fmtok8s-agenda-rest
   namespace: jx-staging
 - chart: dev2/fmtok8s-c4p-rest
-  version: 0.0.15
+  version: 0.0.16
   name: fmtok8s-c4p-rest
   namespace: jx-staging
 - chart: dev2/fmtok8s-email-rest
@@ -111,4 +111,4 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-staging
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -110,5 +110,9 @@ releases:
   version: 0.0.9
   name: fmtok8s-email-rest
   namespace: jx-staging
+- chart: dev2/fmtok8s-c4p-rest
+  version: 0.0.16
+  name: fmtok8s-c4p-rest
+  namespace: jx-production
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -111,4 +111,4 @@ releases:
   name: fmtok8s-email-rest
   namespace: jx-staging
 templates: {}
-renderedvalues: {}
+missingFileHandler: ""


### PR DESCRIPTION
chore: promote fmtok8s-c4p-rest to version 0.0.16

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
