### PR TITLE
chore: promote learnk10s to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/learnk10s/learnk10s-ingress.yaml
+++ b/config-root/namespaces/jx-staging/learnk10s/learnk10s-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: learnk10s/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: learnk10s
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: learnk10s
+              servicePort: 80
+      host: learnk10s-jx-staging.35.222.17.41.nip.io

--- a/config-root/namespaces/jx-staging/learnk10s/learnk10s-learnk10s-deploy.yaml
+++ b/config-root/namespaces/jx-staging/learnk10s/learnk10s-learnk10s-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: learnk10s/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: learnk10s-learnk10s
+  labels:
+    draft: draft-app
+    chart: "learnk10s-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: learnk10s-learnk10s
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: learnk10s-learnk10s
+    spec:
+      serviceAccountName: learnk10s-learnk10s
+      containers:
+        - name: learnk10s
+          image: "gcr.io/camunda-researchanddevelopment/learnk10s:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/learnk10s/learnk10s-learnk10s-sa.yaml
+++ b/config-root/namespaces/jx-staging/learnk10s/learnk10s-learnk10s-sa.yaml
@@ -1,0 +1,8 @@
+# Source: learnk10s/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: learnk10s-learnk10s
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/learnk10s/learnk10s-svc.yaml
+++ b/config-root/namespaces/jx-staging/learnk10s/learnk10s-svc.yaml
@@ -1,0 +1,21 @@
+# Source: learnk10s/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: learnk10s
+  labels:
+    chart: "learnk10s-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: learnk10s-learnk10s

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -94,5 +94,9 @@ releases:
   namespace: jx
   values:
   - versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
+- chart: dev2/learnk10s
+  version: 0.0.1
+  name: learnk10s
+  namespace: jx-staging
 templates: {}
-missingFileHandler: ""
+renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -99,5 +99,4 @@ releases:
   name: learnk10s
   namespace: jx-staging
 templates: {}
-renderedvalues: {}
-
+missingFileHandler: ""

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -100,3 +100,4 @@ releases:
   namespace: jx-staging
 templates: {}
 renderedvalues: {}
+


### PR DESCRIPTION
chore: promote learnk10s to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
