### PR TITLE
chore: promote learnk10s to version 0.0.2

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev2/learnk10s
-  version: 0.0.1
+  version: 0.0.2
   name: learnk10s
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote learnk10s to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
