### PR TITLE
chore: promote learnk10s to version 0.0.3

### DIFF
--- a/config-root/namespaces/jx-staging/learnk10s/learnk10s-learnk10s-deploy.yaml
+++ b/config-root/namespaces/jx-staging/learnk10s/learnk10s-learnk10s-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: learnk10s-learnk10s
   labels:
     draft: draft-app
-    chart: "learnk10s-0.0.1"
+    chart: "learnk10s-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: learnk10s-learnk10s
       containers:
         - name: learnk10s
-          image: "gcr.io/camunda-researchanddevelopment/learnk10s:0.0.1"
+          image: "gcr.io/camunda-researchanddevelopment/learnk10s:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.3
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/learnk10s/learnk10s-svc.yaml
+++ b/config-root/namespaces/jx-staging/learnk10s/learnk10s-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: learnk10s
   labels:
-    chart: "learnk10s-0.0.1"
+    chart: "learnk10s-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev2/learnk10s
-  version: 0.0.1
+  version: 0.0.3
   name: learnk10s
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote learnk10s to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
