### PR TITLE
chore: promote learnk8s to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/learnk8s/learnk8s-ingress.yaml
+++ b/config-root/namespaces/jx-staging/learnk8s/learnk8s-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: learnk8s/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: learnk8s
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: learnk8s
+              servicePort: 80
+      host: learnk8s-jx-staging.104.154.179.98.nip.io

--- a/config-root/namespaces/jx-staging/learnk8s/learnk8s-learnk8s-deploy.yaml
+++ b/config-root/namespaces/jx-staging/learnk8s/learnk8s-learnk8s-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: learnk8s/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: learnk8s-learnk8s
+  labels:
+    draft: draft-app
+    chart: "learnk8s-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: learnk8s-learnk8s
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: learnk8s-learnk8s
+    spec:
+      serviceAccountName: learnk8s-learnk8s
+      containers:
+        - name: learnk8s
+          image: "gcr.io/camunda-researchanddevelopment/learnk8s:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/learnk8s/learnk8s-learnk8s-sa.yaml
+++ b/config-root/namespaces/jx-staging/learnk8s/learnk8s-learnk8s-sa.yaml
@@ -1,0 +1,8 @@
+# Source: learnk8s/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: learnk8s-learnk8s
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/learnk8s/learnk8s-svc.yaml
+++ b/config-root/namespaces/jx-staging/learnk8s/learnk8s-svc.yaml
@@ -1,0 +1,21 @@
+# Source: learnk8s/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: learnk8s
+  labels:
+    chart: "learnk8s-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: learnk8s-learnk8s

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev2/learnk8s
   version: 0.0.1
   name: learnk8s
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: learnk10s
   values:
   - jx-values.yaml
+- chart: dev2/learnk8s
+  version: 0.0.1
+  name: learnk8s
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote learnk8s to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
