### PR TITLE
chore: promote learnk8s to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/learnk8s/learnk8s-learnk8s-deploy.yaml
+++ b/config-root/namespaces/jx-staging/learnk8s/learnk8s-learnk8s-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: learnk8s-learnk8s
   labels:
     draft: draft-app
-    chart: "learnk8s-0.0.1"
+    chart: "learnk8s-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: learnk8s-learnk8s
       containers:
         - name: learnk8s
-          image: "gcr.io/camunda-researchanddevelopment/learnk8s:0.0.1"
+          image: "gcr.io/camunda-researchanddevelopment/learnk8s:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/learnk8s/learnk8s-svc.yaml
+++ b/config-root/namespaces/jx-staging/learnk8s/learnk8s-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: learnk8s
   labels:
-    chart: "learnk8s-0.0.1"
+    chart: "learnk8s-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev2/learnk8s
-  version: 0.0.1
+  version: 0.0.2
   name: learnk8s
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote learnk8s to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
