### PR TITLE
chore: promote zeebe-operator to version 0.0.100

### DIFF
--- a/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-aggregate-edit-clusterrole.yaml
+++ b/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-aggregate-edit-clusterrole.yaml
@@ -1,0 +1,28 @@
+# Source: zeebe-operator/charts/tekton/templates/clusterrole-aggregate-edit.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-aggregate-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    gitops.jenkins-x.io/pipeline: 'cluster'
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - tasks
+      - taskruns
+      - pipelines
+      - pipelineruns
+      - pipelineresources
+      - conditions
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-aggregate-view-clusterrole.yaml
+++ b/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-aggregate-view-clusterrole.yaml
@@ -1,0 +1,22 @@
+# Source: zeebe-operator/charts/tekton/templates/clusterrole-aggregate-view.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-aggregate-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    gitops.jenkins-x.io/pipeline: 'cluster'
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - tasks
+      - taskruns
+      - pipelines
+      - pipelineruns
+      - pipelineresources
+      - conditions
+    verbs:
+      - get
+      - list
+      - watch

--- a/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-bot-clusterrole.yaml
+++ b/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-bot-clusterrole.yaml
@@ -1,0 +1,38 @@
+# Source: zeebe-operator/charts/tekton/templates/build-bot-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-bot
+  labels:
+    gitops.jenkins-x.io/pipeline: 'cluster'
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get

--- a/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-bot-jx-staging-crb.yaml
+++ b/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-bot-jx-staging-crb.yaml
@@ -1,0 +1,16 @@
+# Source: zeebe-operator/charts/tekton/templates/build-bot-clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-bot-jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'cluster'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  # name: tekton-bot
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tekton-bot
+    namespace: jx-staging

--- a/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-clusterrole.yaml
+++ b/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-clusterrole.yaml
@@ -1,0 +1,33 @@
+# Source: zeebe-operator/charts/tekton/templates/200-clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines
+  labels:
+    gitops.jenkins-x.io/pipeline: 'cluster'
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/logs", "namespaces", "secrets", "events", "serviceaccounts", "configmaps", "persistentvolumeclaims", "limitranges"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status", "pipelineresources/status"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["tekton-pipelines"]
+    verbs: ["use"]

--- a/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-jx-staging-crb.yaml
+++ b/config-root/cluster/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-jx-staging-crb.yaml
@@ -1,0 +1,28 @@
+# Source: zeebe-operator/charts/tekton/templates/200-clusterrolebinding.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipelines-jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'cluster'
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines
+    namespace: jx-staging
+roleRef:
+  kind: ClusterRole
+  name: tekton-pipelines
+  apiGroup: rbac.authorization.k8s.io

--- a/config-root/cluster/jx-staging/zeebe-operator/zeebe-operator-role-clusterrole.yaml
+++ b/config-root/cluster/jx-staging/zeebe-operator/zeebe-operator-role-clusterrole.yaml
@@ -1,0 +1,112 @@
+# Source: zeebe-operator/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: zeebe-operator-role
+  labels:
+    gitops.jenkins-x.io/pipeline: 'cluster'
+rules:
+  - apiGroups:
+      - zeebe.io
+    resources:
+      - workflows
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - api.zeebe.io
+    resources:
+      - workflows/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+      - statefulsets/status
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - namespaces
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps/status
+      - services/status
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - pods
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineresources
+      - taskruns
+      - tasks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - zeebe.io
+    resources:
+      - zeebeclusters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - zeebe.io
+    resources:
+      - zeebeclusters/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/config-root/cluster/jx-staging/zeebe-operator/zeebe-operator-rolebinding-crb.yaml
+++ b/config-root/cluster/jx-staging/zeebe-operator/zeebe-operator-rolebinding-crb.yaml
@@ -1,0 +1,16 @@
+# Source: zeebe-operator/templates/role_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zeebe-operator-rolebinding
+  labels:
+    gitops.jenkins-x.io/pipeline: 'cluster'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zeebe-operator-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+    #namespace: jx-staging

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/clustertasks.tekton.dev-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/clustertasks.tekton.dev-crd.yaml
@@ -1,0 +1,41 @@
+# Source: zeebe-operator/charts/tekton/templates/300-clustertask.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clustertasks.tekton.dev
+  labels:
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  group: tekton.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+  names:
+    kind: ClusterTask
+    plural: clustertasks
+    categories:
+      - tekton
+      - tekton-pipelines
+  scope: Cluster
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/conditions.tekton.dev-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/conditions.tekton.dev-crd.yaml
@@ -1,0 +1,34 @@
+# Source: zeebe-operator/charts/tekton/templates/300-condition.yaml
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: conditions.tekton.dev
+  labels:
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  group: tekton.dev
+  names:
+    kind: Condition
+    plural: conditions
+    categories:
+      - tekton
+      - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/images.caching.internal.knative.dev-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/images.caching.internal.knative.dev-crd.yaml
@@ -1,0 +1,37 @@
+# Source: zeebe-operator/charts/tekton/templates/300-imagecache.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+      - knative-internal
+      - caching
+    shortNames:
+      - img
+  scope: Namespaced
+  subresources:
+    status: {}

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/pipelineresources.tekton.dev-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/pipelineresources.tekton.dev-crd.yaml
@@ -1,0 +1,34 @@
+# Source: zeebe-operator/charts/tekton/templates/300-resource.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineresources.tekton.dev
+  labels:
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  group: tekton.dev
+  names:
+    kind: PipelineResource
+    plural: pipelineresources
+    categories:
+      - tekton
+      - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/pipelineruns.tekton.dev-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/pipelineruns.tekton.dev-crd.yaml
@@ -1,0 +1,57 @@
+# Source: zeebe-operator/charts/tekton/templates/300-pipelinerun.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+  labels:
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  group: tekton.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+  names:
+    kind: PipelineRun
+    plural: pipelineruns
+    categories:
+      - tekton
+      - tekton-pipelines
+    shortNames:
+      - pr
+      - prs
+  scope: Namespaced
+  additionalPrinterColumns:
+    - name: Succeeded
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+    - name: Reason
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+    - name: StartTime
+      type: date
+      JSONPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      JSONPath: .status.completionTime
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/pipelines.tekton.dev-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/pipelines.tekton.dev-crd.yaml
@@ -1,0 +1,41 @@
+# Source: zeebe-operator/charts/tekton/templates/300-pipeline.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelines.tekton.dev
+  labels:
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  group: tekton.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+  names:
+    kind: Pipeline
+    plural: pipelines
+    categories:
+      - tekton
+      - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/taskruns.tekton.dev-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/taskruns.tekton.dev-crd.yaml
@@ -1,0 +1,57 @@
+# Source: zeebe-operator/charts/tekton/templates/300-taskrun.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: taskruns.tekton.dev
+  labels:
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  group: tekton.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+  names:
+    kind: TaskRun
+    plural: taskruns
+    categories:
+      - tekton
+      - tekton-pipelines
+    shortNames:
+      - tr
+      - trs
+  scope: Namespaced
+  additionalPrinterColumns:
+    - name: Succeeded
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+    - name: Reason
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+    - name: StartTime
+      type: date
+      JSONPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      JSONPath: .status.completionTime
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/tasks.tekton.dev-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/charts/tekton/tasks.tekton.dev-crd.yaml
@@ -1,0 +1,41 @@
+# Source: zeebe-operator/charts/tekton/templates/300-task.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tasks.tekton.dev
+  labels:
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  group: tekton.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+  names:
+    kind: Task
+    plural: tasks
+    categories:
+      - tekton
+      - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/releases.jenkins.io-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/releases.jenkins.io-crd.yaml
@@ -1,0 +1,712 @@
+# Source: zeebe-operator/crds/jenkins-x-release-crd.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: releases.jenkins.io
+  labels:
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .spec.name
+      description: The name of the Release
+      name: Name
+      type: string
+    - JSONPath: .spec.version
+      description: The version number of the Release
+      name: Version
+      type: string
+    - JSONPath: .spec.gitHttpUrl
+      description: The URL of the Git repository
+      name: Git URL
+      type: string
+  conversion:
+    strategy: None
+  group: jenkins.io
+  names:
+    categories:
+      - all
+    kind: Release
+    listKind: ReleaseList
+    plural: releases
+    shortNames:
+      - rel
+    singular: release
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: Release represents a single version of an app that has been released
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+          properties:
+            annotations:
+              description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+            clusterName:
+              description: The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+              type: string
+            creationTimestamp:
+              description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+              format: date-time
+              type: string
+            deletionGracePeriodSeconds:
+              description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+              format: int64
+              type: integer
+            deletionTimestamp:
+              description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+              format: date-time
+              type: string
+            finalizers:
+              description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.
+              items:
+                type: string
+              type: array
+            generateName:
+              description: |-
+                GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+              type: string
+            generation:
+              description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+              format: int64
+              type: integer
+            initializers:
+              description: Initializers tracks the progress of initialization.
+              properties:
+                pending:
+                  description: Pending is a list of initializers that must execute in order before this object is visible. When the last pending initializer is removed, and no failing result is set, the initializers struct will be set to nil and the object is considered as initialized and visible to all clients.
+                  items:
+                    description: Initializer is information about an initializer that has not yet completed.
+                    properties:
+                      name:
+                        description: name of the process that is responsible for initializing this object.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                result:
+                  description: Status is a return value for calls that don't return other objects.
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    code:
+                      description: Suggested HTTP return code for this status, 0 if not set.
+                      format: int32
+                      type: integer
+                    details:
+                      description: StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.
+                      properties:
+                        causes:
+                          description: The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.
+                          items:
+                            description: StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.
+                            properties:
+                              field:
+                                description: |-
+                                  The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                  Examples:
+                                    "name" - the field "name" on the current resource
+                                    "items[0].name" - the field "name" on the first array entry in "items"
+                                type: string
+                              message:
+                                description: A human-readable description of the cause of the error.  This field may be presented as-is to a reader.
+                                type: string
+                              reason:
+                                description: A machine-readable description of the cause of the error. If this value is empty there is no information available.
+                                type: string
+                            type: object
+                          type: array
+                        group:
+                          description: The group attribute of the resource associated with the status StatusReason.
+                          type: string
+                        kind:
+                          description: 'The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).
+                          type: string
+                        retryAfterSeconds:
+                          description: If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.
+                          format: int32
+                          type: integer
+                        uid:
+                          description: 'UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                          type: string
+                      type: object
+                    kind:
+                      description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    message:
+                      description: A human-readable description of the status of this operation.
+                      type: string
+                    metadata:
+                      description: ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.
+                      properties:
+                        continue:
+                          description: continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.
+                          type: string
+                        resourceVersion:
+                          description: 'String that identifies the server''s internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        selfLink:
+                          description: selfLink is a URL representing this object. Populated by the system. Read-only.
+                          type: string
+                      type: object
+                    reason:
+                      description: A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
+                      type: string
+                    status:
+                      description: 'Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                      type: string
+                  type: object
+              required:
+                - pending
+              type: object
+            labels:
+              description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            name:
+              description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: |-
+                Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+              type: string
+            ownerReferences:
+              description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+              items:
+                description: OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  blockOwnerDeletion:
+                    description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                    type: boolean
+                  controller:
+                    description: If true, this reference points to the managing controller.
+                    type: boolean
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                    type: string
+                required:
+                  - apiVersion
+                  - kind
+                  - name
+                  - uid
+                type: object
+              type: array
+            resourceVersion:
+              description: |-
+                An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+              type: string
+            selfLink:
+              description: SelfLink is a URL representing this object. Populated by the system. Read-only.
+              type: string
+            uid:
+              description: |-
+                UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+              type: string
+          type: object
+        spec:
+          description: ReleaseSpec is the specification of the Release
+          properties:
+            commits:
+              items:
+                description: CommitSummary is the summary of a commit
+                properties:
+                  author:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  branch:
+                    type: string
+                  committer:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  issueIds:
+                    items:
+                      type: string
+                    type: array
+                  message:
+                    type: string
+                  sha:
+                    type: string
+                  url:
+                    type: string
+                type: object
+              type: array
+            dependencyUpdates:
+              items:
+                description: DependencyUpdate describes an dependency update message from the commit log
+                properties:
+                  component:
+                    type: string
+                  fromReleaseHTMLURL:
+                    type: string
+                  fromReleaseName:
+                    type: string
+                  fromVersion:
+                    type: string
+                  host:
+                    type: string
+                  owner:
+                    type: string
+                  paths:
+                    items:
+                      items:
+                        description: DependencyUpdateDetails are the details of a dependency update
+                        properties:
+                          component:
+                            type: string
+                          fromReleaseHTMLURL:
+                            type: string
+                          fromReleaseName:
+                            type: string
+                          fromVersion:
+                            type: string
+                          host:
+                            type: string
+                          owner:
+                            type: string
+                          repo:
+                            type: string
+                          toReleaseHTMLURL:
+                            type: string
+                          toReleaseName:
+                            type: string
+                          toVersion:
+                            type: string
+                          url:
+                            type: string
+                        required:
+                          - host
+                          - owner
+                          - repo
+                          - url
+                          - fromVersion
+                          - fromReleaseHTMLURL
+                          - fromReleaseName
+                          - toVersion
+                          - toReleaseHTMLURL
+                          - toReleaseName
+                        type: object
+                      type: array
+                    type: array
+                  repo:
+                    type: string
+                  toReleaseHTMLURL:
+                    type: string
+                  toReleaseName:
+                    type: string
+                  toVersion:
+                    type: string
+                  url:
+                    type: string
+                required:
+                  - host
+                  - owner
+                  - repo
+                  - url
+                  - fromVersion
+                  - fromReleaseHTMLURL
+                  - fromReleaseName
+                  - toVersion
+                  - toReleaseHTMLURL
+                  - toReleaseName
+                type: object
+              type: array
+            gitCloneUrl:
+              type: string
+            gitHttpUrl:
+              type: string
+            gitOwner:
+              type: string
+            gitRepository:
+              type: string
+            issues:
+              items:
+                description: IssueSummary is the summary of an issue
+                properties:
+                  assignees:
+                    items:
+                      description: UserDetails containers details of a user
+                      properties:
+                        accountReference:
+                          items:
+                            description: AccountReference is a reference to a user account in another system that is attached to this user
+                            properties:
+                              id:
+                                type: string
+                              provider:
+                                type: string
+                            type: object
+                          type: array
+                        avatarUrl:
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                          format: date-time
+                          type: string
+                        email:
+                          type: string
+                        externalUser:
+                          type: boolean
+                        login:
+                          type: string
+                        name:
+                          type: string
+                        serviceAccount:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                  body:
+                    type: string
+                  closedBy:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  creationTimestamp:
+                    description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                    format: date-time
+                    type: string
+                  id:
+                    type: string
+                  labels:
+                    items:
+                      properties:
+                        color:
+                          type: string
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                  message:
+                    type: string
+                  state:
+                    type: string
+                  title:
+                    type: string
+                  url:
+                    type: string
+                  user:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                type: object
+              type: array
+            name:
+              type: string
+            pullRequests:
+              items:
+                description: IssueSummary is the summary of an issue
+                properties:
+                  assignees:
+                    items:
+                      description: UserDetails containers details of a user
+                      properties:
+                        accountReference:
+                          items:
+                            description: AccountReference is a reference to a user account in another system that is attached to this user
+                            properties:
+                              id:
+                                type: string
+                              provider:
+                                type: string
+                            type: object
+                          type: array
+                        avatarUrl:
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                          format: date-time
+                          type: string
+                        email:
+                          type: string
+                        externalUser:
+                          type: boolean
+                        login:
+                          type: string
+                        name:
+                          type: string
+                        serviceAccount:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                  body:
+                    type: string
+                  closedBy:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  creationTimestamp:
+                    description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                    format: date-time
+                    type: string
+                  id:
+                    type: string
+                  labels:
+                    items:
+                      properties:
+                        color:
+                          type: string
+                        name:
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    type: array
+                  message:
+                    type: string
+                  state:
+                    type: string
+                  title:
+                    type: string
+                  url:
+                    type: string
+                  user:
+                    description: UserDetails containers details of a user
+                    properties:
+                      accountReference:
+                        items:
+                          description: AccountReference is a reference to a user account in another system that is attached to this user
+                          properties:
+                            id:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        type: array
+                      avatarUrl:
+                        type: string
+                      creationTimestamp:
+                        description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                      email:
+                        type: string
+                      externalUser:
+                        type: boolean
+                      login:
+                        type: string
+                      name:
+                        type: string
+                      serviceAccount:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                type: object
+              type: array
+            releaseNotesURL:
+              type: string
+            version:
+              type: string
+          type: object
+        status:
+          description: ReleaseStatus is the status of a release
+          properties:
+            status:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    categories:
+      - all
+    kind: Release
+    listKind: ReleaseList
+    plural: releases
+    shortNames:
+      - rel
+    singular: release
+  conditions:
+    - lastTransitionTime: "2020-03-30T19:10:44Z"
+      message: no conflicts found
+      reason: NoConflicts
+      status: "True"
+      type: NamesAccepted
+    - lastTransitionTime: null
+      message: the initial names have been accepted
+      reason: InitialNamesAccepted
+      status: "True"
+      type: Established
+  storedVersions:
+    - v1

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/workflows.zeebe.io-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/workflows.zeebe.io-crd.yaml
@@ -1,0 +1,61 @@
+# Source: zeebe-operator/crds/zeebe.io_workflows.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: workflows.zeebe.io
+  labels:
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .spec.clusterName
+      name: Cluster Name
+      type: string
+  group: zeebe.io
+  names:
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
+    shortNames:
+      - wf
+    singular: workflow
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: Workflow is the Schema for the workflows API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: WorkflowSpec defines the desired state of Workflow
+          properties:
+            clusterName:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
+              type: string
+            workflowDefinitionContent:
+              type: string
+            workflowDefinitionName:
+              type: string
+          type: object
+        status:
+          description: WorkflowStatus defines the observed state of Workflow
+          type: object
+      type: object
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config-root/customresourcedefinitions/jx-staging/zeebe-operator/zeebeclusters.zeebe.io-crd.yaml
+++ b/config-root/customresourcedefinitions/jx-staging/zeebe-operator/zeebeclusters.zeebe.io-crd.yaml
@@ -1,0 +1,104 @@
+# Source: zeebe-operator/crds/zeebe.io_zeebeclusters.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: zeebeclusters.zeebe.io
+  labels:
+    gitops.jenkins-x.io/pipeline: 'customresourcedefinitions'
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.statusName
+      name: Status
+      type: string
+    - JSONPath: .spec.serviceName
+      name: Service
+      type: string
+    - JSONPath: .status.health
+      name: Health
+      type: string
+  group: zeebe.io
+  names:
+    kind: ZeebeCluster
+    listKind: ZeebeClusterList
+    plural: zeebeclusters
+    shortNames:
+      - zb
+    singular: zeebecluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ZeebeCluster is the Schema for the zeebeclusters API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ZeebeClusterSpec defines the desired state of ZeebeCluster
+          properties:
+            operateEnabled:
+              type: boolean
+            serviceName:
+              type: string
+            statefulSetName:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
+              type: string
+            zeebeHealthChecksEnabled:
+              type: boolean
+          type: object
+        status:
+          description: ZeebeClusterStatus defines the observed state of ZeebeCluster
+          properties:
+            clusterName:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
+              type: string
+            conditions:
+              items:
+                properties:
+                  lastProbeTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                  - status
+                  - type
+                type: object
+              type: array
+            health:
+              type: string
+            statusName:
+              type: string
+          required:
+            - clusterName
+            - health
+            - statusName
+          type: object
+      type: object
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-artifact-bucket-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-artifact-bucket-cm.yaml
@@ -1,0 +1,32 @@
+# Source: zeebe-operator/charts/tekton/templates/config-artifact-bucket.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-artifact-bucket
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+data:
+# location of the gcs bucket to be used for artifact storage
+# location: "gs://bucket-name"
+
+# name of the secret that will contain the credentials for the service account
+# with access to the bucket
+# bucket.service.account.secret.name: 
+
+# The key in the secret with the required service account json
+# bucket.service.account.secret.key:

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-artifact-pvc-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-artifact-pvc-cm.yaml
@@ -1,0 +1,25 @@
+# Source: zeebe-operator/charts/tekton/templates/config-artifact-pvc.yaml
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-artifact-pvc
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+data:
+  # default size of the PVC mounted
+  size: "5Gi"

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-defaults-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-defaults-cm.yaml
@@ -1,0 +1,42 @@
+# Source: zeebe-operator/charts/tekton/templates/config-defaults.yaml
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # default-timeout-minutes contains the default number of
+    # minutes to use for TaskRun, if none is specified.
+    default-timeout-minutes: "60"  # 60 minutes

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-entrypoint-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-entrypoint-cm.yaml
@@ -1,0 +1,25 @@
+# Source: zeebe-operator/charts/tekton/templates/config-entrypoint.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-entrypoint
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+data:
+  # entrypoint image which will used by taskrun to capture logs
+  image: "gcr.io/k8s-prow/entrypoint@sha256:7c7cd8906ce4982ffee326218e9fc75da2d4896d53cabc9833b9cc8d2d6b2b8f"

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-logging-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-logging-cm.yaml
@@ -1,0 +1,52 @@
+# Source: zeebe-operator/charts/tekton/templates/config-logging.yaml
+# Copyright 2018 Knative Authors LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+data:
+  # Common configuration for all knative codebase
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "sampling": {
+        "initial": 100,
+        "thereafter": 100
+      },
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+  # Log level overrides
+  loglevel.controller: "info"
+  loglevel.webhook: "info"

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-observability-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config-observability-cm.yaml
@@ -1,0 +1,56 @@
+# Source: zeebe-operator/charts/tekton/templates/config-observability.yaml
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using Stackdriver will incur additional charges.
+    metrics.backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the Stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used and metrics will be sent to the cluster's project if this field is
+    # not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed
+    # to send metrics to Stackdriver using "global" resource type and custom
+    # metric type. Setting this flag to "true" could cause extra Stackdriver
+    # charge.  If metrics.backend-destination is not Stackdriver, this is
+    # ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -1,0 +1,37 @@
+# Source: zeebe-operator/charts/tekton/templates/500-webhooks.yaml
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.pipeline.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.11.3
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: jx-staging
+    failurePolicy: Fail
+    sideEffects: None
+    name: config.webhook.pipeline.tekton.dev
+    namespaceSelector:
+      matchExpressions:
+        - key: pipeline.tekton.dev/release
+          operator: Exists

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/feature-flags-cm.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/feature-flags-cm.yaml
@@ -1,0 +1,43 @@
+# Source: zeebe-operator/charts/tekton/templates/config-feature-flags.yaml
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+data:
+  # Setting this flag to "true" will prevent Tekton overriding your
+  # Task container's $HOME environment variable.
+  #
+  # The default behaviour currently is for Tekton to override the
+  # $HOME environment variable but this will change in an upcoming
+  # release.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/2013 for more
+  # info.
+  disable-home-env-overwrite: "false"
+  # Setting this flag to "true" will prevent Tekton overriding your
+  # Task container's working directory.
+  #
+  # The default behaviour currently is for Tekton to override the
+  # working directory if not set by the user but this will change
+  # in an upcoming release.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/1836 for more
+  # info.
+  disable-working-directory-overwrite: "false"

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-bot-rb.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-bot-rb.yaml
@@ -1,0 +1,16 @@
+# Source: zeebe-operator/charts/tekton/templates/build-bot-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-bot
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-bot
+subjects:
+  - kind: ServiceAccount
+    name: tekton-bot
+    namespace: jx-staging

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-bot-role.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-bot-role.yaml
@@ -1,0 +1,15 @@
+# Source: zeebe-operator/charts/tekton/templates/build-bot-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-bot
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - "*"

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-bot-sa.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-bot-sa.yaml
@@ -1,0 +1,22 @@
+# Source: zeebe-operator/charts/tekton/templates/251-bot-serviceaccount.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-bot
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+secrets:

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-controller-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-controller-deploy.yaml
@@ -1,0 +1,72 @@
+# Source: zeebe-operator/charts/tekton/templates/controller.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: jx-staging
+  labels:
+    app.kubernetes.io/name: tekton-pipelines
+    app.kubernetes.io/component: controller
+    pipeline.tekton.dev/release: v0.11.3
+    version: v0.11.3
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-pipelines-controller
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: tekton-pipelines-controller
+        app.kubernetes.io/name: tekton-pipelines
+        app.kubernetes.io/component: controller
+        pipeline.tekton.dev/release: v0.11.3
+        version: v0.11.3
+    spec:
+      serviceAccountName: tekton-pipelines
+      containers:
+        - name: tekton-pipelines
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.11.3
+          args: ["-logtostderr", "-stderrthreshold", "INFO", "-kubeconfig-writer-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.11.3", "-creds-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init:v0.11.3", "-git-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.11.3", "-nop-image", "tianon/true", "-shell-image", "busybox", "-gsutil-image", "google/cloud-sdk", "-entrypoint-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.11.3", "-pr-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.11.3", "-imagedigest-exporter-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter.v0.11.3", "-build-gcs-fetcher-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/vendor/github.com/googlecloudplatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher.v0.11.3", "-namespace", "jx-staging"]
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: CONFIG_ARTIFACT_BUCKET_NAME
+              value: config-artifact-bucket
+            - name: CONFIG_ARTIFACT_PVC_NAME
+              value: config-artifact-pvc
+            - name: METRICS_DOMAIN
+              value: tekton.dev/pipeline
+            - name: KUBERNETES_MIN_VERSION
+              value: v1.14.0
+          volumeMounts:
+            - name: config-logging
+              mountPath: /etc/config-logging
+      volumes:
+        - name: config-logging
+          configMap:
+            name: config-logging

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-controller-svc.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-controller-svc.yaml
@@ -1,0 +1,19 @@
+# Source: zeebe-operator/charts/tekton/templates/controller.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-pipelines-controller
+    pipeline.tekton.dev/release: v0.11.3
+    version: v0.11.3
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  name: tekton-pipelines-controller
+  namespace: jx-staging
+spec:
+  ports:
+    - name: http-metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app: tekton-pipelines-controller

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-podsecuritypolicy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-podsecuritypolicy.yaml
@@ -1,0 +1,45 @@
+# Source: zeebe-operator/charts/tekton/templates/101-podsecuritypolicy.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: tekton-pipelines
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'emptyDir'
+    - 'configMap'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-sa.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-sa.yaml
@@ -1,0 +1,21 @@
+# Source: zeebe-operator/charts/tekton/templates/250-serviceaccount.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-pipelines
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-webhook-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-webhook-deploy.yaml
@@ -1,0 +1,76 @@
+# Source: zeebe-operator/charts/tekton/templates/webhook.yaml
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-webhook
+  namespace: jx-staging
+  labels:
+    app.kubernetes.io/name: tekton-pipelines
+    app.kubernetes.io/component: webhook-controller
+    pipeline.tekton.dev/release: v0.11.3
+    version: v0.11.3
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-pipelines-webhook
+      role: webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: tekton-pipelines-webhook
+        role: webhook
+        app.kubernetes.io/name: tekton-pipelines
+        app.kubernetes.io/component: webhook-controller
+        pipeline.tekton.dev/release: v0.11.3
+        version: v0.11.3
+    spec:
+      serviceAccountName: tekton-pipelines
+      containers:
+        - name: webhook
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.11.3
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: WEBHOOK_SERVICE_NAME
+              value: tekton-pipelines-webhook
+            - name: METRICS_DOMAIN
+              value: tekton.dev/pipeline
+            - name: KUBERNETES_MIN_VERSION
+              value: v1.14.0
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: https-webhook
+              containerPort: 8443
+          securityContext:
+            allowPrivilegeEscalation: false

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-webhook-svc.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/tekton-pipelines-webhook-svc.yaml
@@ -1,0 +1,27 @@
+# Source: zeebe-operator/charts/tekton/templates/webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-pipelines-webhook
+    role: webhook
+    pipeline.tekton.dev/release: v0.11.3
+    version: v0.11.3
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  name: tekton-pipelines-webhook
+  namespace: jx-staging
+spec:
+  ports:
+    # Define metrics and profiling for them to be accessible within service meshes.
+    - name: http-metrics
+      port: 9090
+      targetPort: 9090
+    - name: http-profiling
+      port: 8008
+      targetPort: 8008
+    - name: https-webhook
+      port: 443
+      targetPort: 8443
+  selector:
+    app: tekton-pipelines-webhook
+    role: webhook

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -1,0 +1,33 @@
+# Source: zeebe-operator/charts/tekton/templates/500-webhooks.yaml
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.pipeline.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.11.3
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: jx-staging
+    failurePolicy: Fail
+    sideEffects: None
+    name: validation.webhook.pipeline.tekton.dev

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/webhook-certs-secret.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/webhook-certs-secret.yaml
@@ -1,0 +1,23 @@
+# Source: zeebe-operator/charts/tekton/templates/500-webhooks.yaml
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-certs
+  namespace: jx-staging
+  labels:
+    pipeline.tekton.dev/release: v0.11.3
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/charts/tekton/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
@@ -1,0 +1,33 @@
+# Source: zeebe-operator/charts/tekton/templates/500-webhooks.yaml
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.pipeline.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.11.3
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: jx-staging
+    failurePolicy: Fail
+    sideEffects: None
+    name: webhook.pipeline.tekton.dev

--- a/config-root/namespaces/jx-staging/zeebe-operator/zeebe-operator-svc.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/zeebe-operator-svc.yaml
@@ -1,0 +1,21 @@
+# Source: zeebe-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: zeebe-operator
+  labels:
+    chart: "zeebe-operator-0.0.100"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: zeebe-operator-zeebe-operator

--- a/config-root/namespaces/jx-staging/zeebe-operator/zeebe-operator-zeebe-operator-deploy.yaml
+++ b/config-root/namespaces/jx-staging/zeebe-operator/zeebe-operator-zeebe-operator-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: zeebe-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zeebe-operator-zeebe-operator
+  labels:
+    draft: draft-app
+    chart: "zeebe-operator-0.0.100"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: zeebe-operator-zeebe-operator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: zeebe-operator-zeebe-operator
+    spec:
+      containers:
+        - name: zeebe-operator
+          image: "gcr.io/camunda-researchanddevelopment/zeebe-operator:0.0.100"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: BUILDER_IMAGE
+              value: "gcr.io/camunda-consulting-de/helm-builder:0.0.1"
+            - name: PIPELINES_NAMESPACE
+              value: "default"
+            - name: PIPELINES_SA
+              value: "tekton-bot"
+            - name: VERSION_STREAM
+              value: "http://github.com/zeebe-io/zeebe-version-stream-helm"
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 80m
+              memory: 128Mi
+      terminationGracePeriodSeconds:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev2/zeebe-operator
   version: 0.0.100
   name: zeebe-operator
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,5 +7,9 @@ namespace: jx-staging
 repositories:
 - name: dev2
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+releases:
+- chart: dev2/zeebe-operator
+  version: 0.0.100
+  name: zeebe-operator
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote zeebe-operator to version 0.0.100

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
